### PR TITLE
Fix badge layout in OS X 10.11

### DIFF
--- a/RealmBrowser/Classes/RLMSidebarTableCellView.m
+++ b/RealmBrowser/Classes/RLMSidebarTableCellView.m
@@ -25,9 +25,15 @@
     [[self.button cell] setBezelStyle:NSInlineBezelStyle];
 }
 
-// The standard rowSizeStyle does some specific layout for us. To customize layout for our button, we first call super and then modify things
-- (void)viewWillDraw {
+- (void)viewWillDraw
+{
     [super viewWillDraw];
+    [self setNeedsLayout:YES];
+}
+
+// The standard rowSizeStyle does some specific layout for us. To customize layout for our button, we first call super and then modify things
+- (void)layout {
+    [super layout];
     
     if (![self.button isHidden]) {
         [self.button sizeToFit];


### PR DESCRIPTION
As reported by @segiddins, the badge icon in the objects table was broken in OS X 10.11.

It turns out that `viewWillDraw` is no longer being called in OS X 10..1, so the layout code for that badge wasn't being called. I've moved that logic to `layout` (Which gets called automatically in 10.11), and added backward support to OS X 10.10 by manually requesting a re-layout when `viewWillDraw` is called.

This whole thing isn't the best solution. It'll work in the interim, but down the line, it would be best to move all of this to Auto Layout.