### PR TITLE
[WIP] Refactoring to proper document model with an RLMArrayController

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: objective-c
-osx_image: xcode6.4
+osx_image: xcode7.1
 script: xctool -workspace "RealmBrowser.xcworkspace" -scheme "Realm Browser" test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/RealmBrowser.xcodeproj/project.pbxproj
+++ b/RealmBrowser.xcodeproj/project.pbxproj
@@ -34,13 +34,19 @@
 		36B669CB1B8B057F00F04AE1 /* RLMObjectLinkSelectionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 36B669CA1B8B057F00F04AE1 /* RLMObjectLinkSelectionViewController.xib */; };
 		36B669CE1B8B096A00F04AE1 /* RLMObjectLinkSelectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 36B669CD1B8B096A00F04AE1 /* RLMObjectLinkSelectionViewController.m */; };
 		36C3D1FFA6C372B1485F381A /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4DD42CE427D384E8A7351A0 /* Pods.framework */; settings = {ATTRIBUTES = (Required, ); }; };
+		420696B71BDEBC940000B74A /* RLMResultsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 420696B61BDEBC940000B74A /* RLMResultsController.m */; };
+		420696E41BDFEE350000B74A /* RLMTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 420696E31BDFEE350000B74A /* RLMTableViewController.m */; };
+		420696E71BE01E490000B74A /* RLMRealmViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 420696E61BE01E490000B74A /* RLMRealmViewController.m */; };
+		420696EA1BE023C40000B74A /* RLMTableViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 420696E81BE023C40000B74A /* RLMTableViewController.xib */; };
+		420696ED1BE063360000B74A /* RLMTableRowView.m in Sources */ = {isa = PBXBuildFile; fileRef = 420696EC1BE063360000B74A /* RLMTableRowView.m */; };
+		420696F01BE10E280000B74A /* RLMResultsControllerArray.m in Sources */ = {isa = PBXBuildFile; fileRef = 420696EF1BE10E280000B74A /* RLMResultsControllerArray.m */; };
+		420696F31BE13A1A0000B74A /* RLMResultsControllerObservationProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 420696F21BE13A1A0000B74A /* RLMResultsControllerObservationProxy.m */; };
 		840F97C0192B7DCE006B591E /* RLMDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 840F97BF192B7DCE006B591E /* RLMDocument.m */; };
 		84446534195891AA00CEEA5B /* RLMViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 84446533195891AA00CEEA5B /* RLMViewController.m */; };
 		844C34E3194859080027E902 /* TestClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = 844C34E2194859080027E902 /* TestClasses.m */; };
 		8457294D1962E3860076D4F1 /* RLMTableView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8457294C1962E3860076D4F1 /* RLMTableView.m */; };
 		8474E2B419544D8000BCA755 /* RLMTypeOutlineViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8474E2B319544D8000BCA755 /* RLMTypeOutlineViewController.m */; };
 		8474E2BD195452BE00BCA755 /* RLMInstanceTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8474E2BC195452BE00BCA755 /* RLMInstanceTableViewController.m */; };
-		84754ABE193CA4600093604E /* RLMRealmBrowserWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 84754ABD193CA4600093604E /* RLMRealmBrowserWindowController.m */; };
 		84925C61195AD5B000EE27B1 /* NSColor+ByteSizeFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 84925C60195AD5B000EE27B1 /* NSColor+ByteSizeFactory.m */; };
 		84925C67195AE9AD00EE27B1 /* RLMSidebarTableCellView.m in Sources */ = {isa = PBXBuildFile; fileRef = 84925C66195AE9AD00EE27B1 /* RLMSidebarTableCellView.m */; };
 		84A34A4F192E19C5005D6CC4 /* RLMApplicationDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 84A34A4E192E19C5005D6CC4 /* RLMApplicationDelegate.m */; };
@@ -139,6 +145,19 @@
 		36B669CA1B8B057F00F04AE1 /* RLMObjectLinkSelectionViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RLMObjectLinkSelectionViewController.xib; sourceTree = "<group>"; };
 		36B669CC1B8B096A00F04AE1 /* RLMObjectLinkSelectionViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMObjectLinkSelectionViewController.h; sourceTree = "<group>"; };
 		36B669CD1B8B096A00F04AE1 /* RLMObjectLinkSelectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMObjectLinkSelectionViewController.m; sourceTree = "<group>"; };
+		420696B51BDEBC940000B74A /* RLMResultsController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMResultsController.h; sourceTree = "<group>"; };
+		420696B61BDEBC940000B74A /* RLMResultsController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMResultsController.m; sourceTree = "<group>"; };
+		420696E21BDFEE350000B74A /* RLMTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RLMTableViewController.h; path = Classes/RLMTableViewController.h; sourceTree = "<group>"; };
+		420696E31BDFEE350000B74A /* RLMTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMTableViewController.m; path = Classes/RLMTableViewController.m; sourceTree = "<group>"; };
+		420696E51BE01E490000B74A /* RLMRealmViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RLMRealmViewController.h; path = Classes/RLMRealmViewController.h; sourceTree = "<group>"; };
+		420696E61BE01E490000B74A /* RLMRealmViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMRealmViewController.m; path = Classes/RLMRealmViewController.m; sourceTree = "<group>"; };
+		420696E91BE023C40000B74A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/RLMTableViewController.xib; sourceTree = "<group>"; };
+		420696EB1BE063360000B74A /* RLMTableRowView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RLMTableRowView.h; path = Classes/RLMTableRowView.h; sourceTree = "<group>"; };
+		420696EC1BE063360000B74A /* RLMTableRowView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMTableRowView.m; path = Classes/RLMTableRowView.m; sourceTree = "<group>"; };
+		420696EE1BE10E280000B74A /* RLMResultsControllerArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RLMResultsControllerArray.h; path = Classes/RLMResultsControllerArray.h; sourceTree = "<group>"; };
+		420696EF1BE10E280000B74A /* RLMResultsControllerArray.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMResultsControllerArray.m; path = Classes/RLMResultsControllerArray.m; sourceTree = "<group>"; };
+		420696F11BE13A1A0000B74A /* RLMResultsControllerObservationProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RLMResultsControllerObservationProxy.h; path = Classes/RLMResultsControllerObservationProxy.h; sourceTree = "<group>"; };
+		420696F21BE13A1A0000B74A /* RLMResultsControllerObservationProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMResultsControllerObservationProxy.m; path = Classes/RLMResultsControllerObservationProxy.m; sourceTree = "<group>"; };
 		840F97BE192B7DCE006B591E /* RLMDocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RLMDocument.h; path = Classes/RLMDocument.h; sourceTree = "<group>"; };
 		840F97BF192B7DCE006B591E /* RLMDocument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMDocument.m; path = Classes/RLMDocument.m; sourceTree = "<group>"; };
 		84446532195891AA00CEEA5B /* RLMViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RLMViewController.h; path = Classes/RLMViewController.h; sourceTree = "<group>"; };
@@ -276,8 +295,12 @@
 				2257869D1BD563A00012436A /* RLMEncryptionKeyWindowController.m */,
 				84754ABC193CA4600093604E /* RLMRealmBrowserWindowController.h */,
 				84754ABD193CA4600093604E /* RLMRealmBrowserWindowController.m */,
+				420696E51BE01E490000B74A /* RLMRealmViewController.h */,
+				420696E61BE01E490000B74A /* RLMRealmViewController.m */,
 				8474E2B219544D8000BCA755 /* RLMTypeOutlineViewController.h */,
 				8474E2B319544D8000BCA755 /* RLMTypeOutlineViewController.m */,
+				420696E21BDFEE350000B74A /* RLMTableViewController.h */,
+				420696E31BDFEE350000B74A /* RLMTableViewController.m */,
 				8474E2BB195452BE00BCA755 /* RLMInstanceTableViewController.h */,
 				8474E2BC195452BE00BCA755 /* RLMInstanceTableViewController.m */,
 				22DC87E41B98086D0024BA34 /* RLMExportIndicatorWindowController.h */,
@@ -297,6 +320,8 @@
 				225443F419E3E6360045996B /* RLMTableHeaderCell.m */,
 				8457294B1962E3860076D4F1 /* RLMTableView.h */,
 				8457294C1962E3860076D4F1 /* RLMTableView.m */,
+				420696EB1BE063360000B74A /* RLMTableRowView.h */,
+				420696EC1BE063360000B74A /* RLMTableRowView.m */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -320,6 +345,12 @@
 				2249D9B119A62EBD00A31104 /* RLMTableColumn.m */,
 				840F97BE192B7DCE006B591E /* RLMDocument.h */,
 				840F97BF192B7DCE006B591E /* RLMDocument.m */,
+				420696B51BDEBC940000B74A /* RLMResultsController.h */,
+				420696B61BDEBC940000B74A /* RLMResultsController.m */,
+				420696EE1BE10E280000B74A /* RLMResultsControllerArray.h */,
+				420696EF1BE10E280000B74A /* RLMResultsControllerArray.m */,
+				420696F11BE13A1A0000B74A /* RLMResultsControllerObservationProxy.h */,
+				420696F21BE13A1A0000B74A /* RLMResultsControllerObservationProxy.m */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -439,6 +470,7 @@
 				22DC87E71B9808790024BA34 /* RLMExportIndicatorWindowController.xib */,
 				36B669CA1B8B057F00F04AE1 /* RLMObjectLinkSelectionViewController.xib */,
 				84E0F9671921F3B900D6CA14 /* MainMenu.xib */,
+				420696E81BE023C40000B74A /* RLMTableViewController.xib */,
 				84E0F96A1921F3B900D6CA14 /* Images.xcassets */,
 				22D5FF911B0DBCC30090CFE6 /* Realm Browser.entitlements */,
 				84BCA5FE1951BC99008FC850 /* Resources */,
@@ -590,6 +622,7 @@
 				84E0F9601921F3B900D6CA14 /* Credits.rtf in Resources */,
 				84E0F9661921F3B900D6CA14 /* RLMDocument.xib in Resources */,
 				84E0F9691921F3B900D6CA14 /* MainMenu.xib in Resources */,
+				420696EA1BE023C40000B74A /* RLMTableViewController.xib in Resources */,
 				22DC87E81B9808790024BA34 /* RLMExportIndicatorWindowController.xib in Resources */,
 				36B669CB1B8B057F00F04AE1 /* RLMObjectLinkSelectionViewController.xib in Resources */,
 			);
@@ -718,17 +751,19 @@
 			files = (
 				22A55FEB19D18BA8009178BC /* RLMObjectNode.m in Sources */,
 				840F97C0192B7DCE006B591E /* RLMDocument.m in Sources */,
+				420696F01BE10E280000B74A /* RLMResultsControllerArray.m in Sources */,
 				84AA41B01949CD7700A50F03 /* RLMArrayNode.m in Sources */,
 				22E4737219924CF700EEF7C9 /* RLMBasicTableCellView.m in Sources */,
 				2257869E1BD563A00012436A /* RLMEncryptionKeyWindowController.m in Sources */,
+				420696E41BDFEE350000B74A /* RLMTableViewController.m in Sources */,
 				22E473791992562400EEF7C9 /* RLMBoolTableCellView.m in Sources */,
 				8474E2BD195452BE00BCA755 /* RLMInstanceTableViewController.m in Sources */,
-				84754ABE193CA4600093604E /* RLMRealmBrowserWindowController.m in Sources */,
 				225443F519E3E6360045996B /* RLMTableHeaderCell.m in Sources */,
 				22D3AC8A19CC5D710042C1B2 /* RLMModelExporter.m in Sources */,
 				84E0F95C1921F3B900D6CA14 /* main.m in Sources */,
 				84925C61195AD5B000EE27B1 /* NSColor+ByteSizeFactory.m in Sources */,
 				844C34E3194859080027E902 /* TestClasses.m in Sources */,
+				420696B71BDEBC940000B74A /* RLMResultsController.m in Sources */,
 				84E35A4D196B021B007F0344 /* RLMArrayNavigationState.m in Sources */,
 				84446534195891AA00CEEA5B /* RLMViewController.m in Sources */,
 				225AAFEC19C09E520023B595 /* RLMTextField.m in Sources */,
@@ -745,15 +780,18 @@
 				84D7990B19388E8900FC76A0 /* RLMClassNode.m in Sources */,
 				84AA41A91949C99800A50F03 /* RLMTypeNode.m in Sources */,
 				22D28EA71993AAAB00497FD3 /* RLMNumberTableCellView.m in Sources */,
+				420696ED1BE063360000B74A /* RLMTableRowView.m in Sources */,
 				3615BDB6196FA8BF00E1AE3F /* RLMQueryNavigationState.m in Sources */,
 				84A34A4F192E19C5005D6CC4 /* RLMApplicationDelegate.m in Sources */,
 				8474E2B419544D8000BCA755 /* RLMTypeOutlineViewController.m in Sources */,
 				2249D9B219A62EBD00A31104 /* RLMTableColumn.m in Sources */,
+				420696F31BE13A1A0000B74A /* RLMResultsControllerObservationProxy.m in Sources */,
 				220D382819B639D700F79496 /* RLMTestDataGenerator.m in Sources */,
 				84E35A42196A9F3B007F0344 /* RLMNavigationState.m in Sources */,
 				84D7990D19388E8900FC76A0 /* RLMRealmNode.m in Sources */,
 				22DC87E61B98086D0024BA34 /* RLMExportIndicatorWindowController.m in Sources */,
 				22565D6719C1BCF400C8C8EC /* RLMLinkTableCellView.m in Sources */,
+				420696E71BE01E490000B74A /* RLMRealmViewController.m in Sources */,
 				221322FA19954AB100D25737 /* RLMImageTableCellView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -784,6 +822,14 @@
 				225786A01BD564F40012436A /* Base */,
 			);
 			name = EncryptionKeyWindow.xib;
+			sourceTree = "<group>";
+		};
+		420696E81BE023C40000B74A /* RLMTableViewController.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				420696E91BE023C40000B74A /* Base */,
+			);
+			name = RLMTableViewController.xib;
 			sourceTree = "<group>";
 		};
 		84E0F9581921F3B900D6CA14 /* InfoPlist.strings */ = {

--- a/RealmBrowser/Base.lproj/RLMDocument.xib
+++ b/RealmBrowser/Base.lproj/RLMDocument.xib
@@ -36,7 +36,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="236" height="564"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <outlineView appearanceType="vibrantLight" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" rowSizeStyle="medium" viewBased="YES" floatsGroupRows="NO" indentationPerLevel="14" outlineTableColumn="ye8-fR-LJ8" id="IMi-6Y-gQF">
+                                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" rowSizeStyle="medium" viewBased="YES" floatsGroupRows="NO" indentationPerLevel="14" outlineTableColumn="ye8-fR-LJ8" id="IMi-6Y-gQF">
                                                     <rect key="frame" x="0.0" y="0.0" width="236" height="0.0"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
@@ -115,11 +115,11 @@
                                             <nil key="backgroundColor"/>
                                         </clipView>
                                         <animations/>
-                                        <scroller key="horizontalScroller" hidden="YES" appearanceType="vibrantLight" verticalHuggingPriority="750" horizontal="YES" id="exH-b9-o3D">
+                                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="exH-b9-o3D">
                                             <autoresizingMask key="autoresizingMask"/>
                                             <animations/>
                                         </scroller>
-                                        <scroller key="verticalScroller" hidden="YES" appearanceType="vibrantLight" verticalHuggingPriority="750" horizontal="NO" id="2YT-v9-0yd">
+                                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="2YT-v9-0yd">
                                             <autoresizingMask key="autoresizingMask"/>
                                             <animations/>
                                         </scroller>

--- a/RealmBrowser/Base.lproj/RLMDocument.xib
+++ b/RealmBrowser/Base.lproj/RLMDocument.xib
@@ -1,29 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9046" systemVersion="14F1017" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9059"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9046"/>
     </dependencies>
     <objects>
-        <customObject id="-2" userLabel="File's Owner" customClass="RLMRealmBrowserWindowController">
+        <customObject id="-2" userLabel="File's Owner" customClass="RLMDocument">
             <connections>
-                <outlet property="lockRealmButton" destination="L8G-EJ-A1Z" id="UgQ-Tm-A3A"/>
-                <outlet property="navigationButtons" destination="2Ep-Z1-kHF" id="R6Y-2D-J2o"/>
-                <outlet property="outlineViewController" destination="hSp-0t-Gbg" id="wTv-NH-RZX"/>
-                <outlet property="searchField" destination="d5n-tM-xUt" id="8FS-BC-KyY"/>
-                <outlet property="splitView" destination="IXc-8a-g01" id="IMn-O6-Eyj"/>
-                <outlet property="tableViewController" destination="X01-Pz-1Ve" id="3ep-TB-FsM"/>
                 <outlet property="window" destination="xOd-HO-29H" id="JIz-fz-R2o"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Realm" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" appearanceType="aqua" animationBehavior="default" id="xOd-HO-29H" userLabel="Window">
+        <window title="Realm" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" appearanceType="aqua" animationBehavior="default" id="xOd-HO-29H" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" texturedBackground="YES" unifiedTitleAndToolbar="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="247" y="192" width="977" height="476"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <value key="minSize" type="size" width="94" height="86"/>
             <view key="contentView" id="gIp-Ho-8D9">
                 <rect key="frame" x="0.0" y="0.0" width="977" height="476"/>
@@ -36,13 +30,13 @@
                                 <rect key="frame" x="0.0" y="0.0" width="236" height="476"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <subviews>
-                                    <scrollView appearanceType="aqua" borderType="none" autohidesScrollers="YES" horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MSf-82-x0U" userLabel="OutlineScroll">
+                                    <scrollView appearanceType="aqua" borderType="none" autohidesScrollers="YES" horizontalLineScroll="24" horizontalPageScroll="10" verticalLineScroll="24" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MSf-82-x0U" userLabel="OutlineScroll">
                                         <rect key="frame" x="0.0" y="0.0" width="236" height="476"/>
                                         <clipView key="contentView" focusRingType="none" drawsBackground="NO" id="udQ-xx-2L4">
                                             <rect key="frame" x="0.0" y="0.0" width="236" height="564"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" multipleSelection="NO" autosaveColumns="NO" rowHeight="22" rowSizeStyle="automatic" viewBased="YES" indentationPerLevel="14" outlineTableColumn="ye8-fR-LJ8" id="IMi-6Y-gQF">
+                                                <outlineView appearanceType="vibrantLight" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" rowSizeStyle="medium" viewBased="YES" floatsGroupRows="NO" indentationPerLevel="14" outlineTableColumn="ye8-fR-LJ8" id="IMi-6Y-gQF">
                                                     <rect key="frame" x="0.0" y="0.0" width="236" height="0.0"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
@@ -63,50 +57,51 @@
                                                             </textFieldCell>
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             <prototypeCellViews>
-                                                                <textField identifier="HeaderLabel" verticalHuggingPriority="750" id="PZp-xm-tfc">
+                                                                <tableCellView identifier="header" id="yKS-J9-6qw">
                                                                     <rect key="frame" x="1" y="0.0" width="233" height="17"/>
-                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                    <animations/>
-                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" usesSingleLineMode="YES" id="ntn-io-NM2">
-                                                                        <font key="font" metaFont="smallSystem"/>
-                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <customView identifier="MainCell" id="O58-xq-8no" userLabel="MainCellView" customClass="RLMSidebarTableCellView">
-                                                                    <rect key="frame" x="1" y="17" width="233" height="22"/>
-                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
-                                                                        <imageView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lUk-zd-1z6">
-                                                                            <rect key="frame" x="6" y="3" width="16" height="16"/>
-                                                                            <animations/>
-                                                                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" id="vIg-OG-e3y"/>
-                                                                        </imageView>
-                                                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EaJ-q6-IlG">
-                                                                            <rect key="frame" x="10" y="2" width="287" height="18"/>
-                                                                            <animations/>
-                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="Row label" id="A0k-QZ-8eL">
+                                                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nOt-og-iQ0">
+                                                                            <rect key="frame" x="0.0" y="1" width="145" height="14"/>
+                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="HEADER CELL" id="pH8-3E-ZTI">
+                                                                                <font key="font" metaFont="smallSystemBold"/>
+                                                                                <color key="textColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                            <connections>
+                                                                                <binding destination="yKS-J9-6qw" name="value" keyPath="objectValue" id="gaP-Qw-TUO"/>
+                                                                            </connections>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <connections>
+                                                                        <outlet property="textField" destination="nOt-og-iQ0" id="VeC-kO-lb8"/>
+                                                                    </connections>
+                                                                </tableCellView>
+                                                                <tableCellView identifier="class" id="2r4-mC-pC1">
+                                                                    <rect key="frame" x="1" y="17" width="233" height="17"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                    <subviews>
+                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="cOe-HT-WT9">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="232" height="17"/>
+                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Class" id="p9d-MH-sbM">
                                                                                 <font key="font" metaFont="system"/>
                                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
+                                                                            <connections>
+                                                                                <binding destination="2r4-mC-pC1" name="value" keyPath="objectValue.className" id="FG2-YT-GCv"/>
+                                                                            </connections>
                                                                         </textField>
-                                                                        <button hidden="YES" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="I1l-Wv-wMz">
-                                                                            <rect key="frame" x="141" y="2" width="104" height="17"/>
-                                                                            <animations/>
-                                                                            <buttonCell key="cell" type="roundRect" title="Instance count" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Lw1-PH-p6Q">
-                                                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                                <font key="font" metaFont="smallSystem"/>
-                                                                            </buttonCell>
-                                                                        </button>
                                                                     </subviews>
-                                                                    <animations/>
+                                                                    <constraints>
+                                                                        <constraint firstItem="cOe-HT-WT9" firstAttribute="leading" secondItem="2r4-mC-pC1" secondAttribute="leading" constant="2" id="fmc-GK-5qU"/>
+                                                                        <constraint firstAttribute="trailing" secondItem="cOe-HT-WT9" secondAttribute="trailing" constant="3" id="hWk-8J-xzU"/>
+                                                                        <constraint firstItem="cOe-HT-WT9" firstAttribute="centerY" secondItem="2r4-mC-pC1" secondAttribute="centerY" id="tRG-L2-hKU"/>
+                                                                    </constraints>
                                                                     <connections>
-                                                                        <outlet property="button" destination="I1l-Wv-wMz" id="bbO-A1-Jhu"/>
-                                                                        <outlet property="imageView" destination="lUk-zd-1z6" id="FU5-UE-blk"/>
-                                                                        <outlet property="textField" destination="EaJ-q6-IlG" id="Mfb-av-BRv"/>
+                                                                        <outlet property="textField" destination="cOe-HT-WT9" id="liD-XA-QkG"/>
                                                                     </connections>
-                                                                </customView>
+                                                                </tableCellView>
                                                             </prototypeCellViews>
                                                         </tableColumn>
                                                     </tableColumns>
@@ -120,11 +115,11 @@
                                             <nil key="backgroundColor"/>
                                         </clipView>
                                         <animations/>
-                                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="exH-b9-o3D">
+                                        <scroller key="horizontalScroller" hidden="YES" appearanceType="vibrantLight" verticalHuggingPriority="750" horizontal="YES" id="exH-b9-o3D">
                                             <autoresizingMask key="autoresizingMask"/>
                                             <animations/>
                                         </scroller>
-                                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="2YT-v9-0yd">
+                                        <scroller key="verticalScroller" hidden="YES" appearanceType="vibrantLight" verticalHuggingPriority="750" horizontal="NO" id="2YT-v9-0yd">
                                             <autoresizingMask key="autoresizingMask"/>
                                             <animations/>
                                         </scroller>
@@ -138,351 +133,9 @@
                                 </constraints>
                                 <animations/>
                             </customView>
-                            <customView id="XsG-4h-zWh" userLabel="MainTableView">
+                            <customView fixedFrame="YES" id="XsG-4h-zWh" userLabel="MainTableView">
                                 <rect key="frame" x="237" y="0.0" width="740" height="476"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <subviews>
-                                    <scrollView focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="20" horizontalPageScroll="10" verticalLineScroll="20" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3b6-BA-X5L" userLabel="MainScroll">
-                                        <rect key="frame" x="0.0" y="0.0" width="740" height="476"/>
-                                        <clipView key="contentView" focusRingType="none" id="kRO-aN-FFM">
-                                            <rect key="frame" x="0.0" y="0.0" width="740" height="476"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <subviews>
-                                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" alternatingRowBackgroundColors="YES" autosaveName="InstanceTable" rowHeight="18" headerView="cDp-e2-1cA" viewBased="YES" id="enp-HN-e6b" customClass="RLMTableView">
-                                                    <rect key="frame" x="0.0" y="0.0" width="918" height="453"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <animations/>
-                                                    <size key="intercellSpacing" width="3" height="2"/>
-                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                    <tableViewGridLines key="gridStyleMask" vertical="YES" horizontal="YES"/>
-                                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
-                                                    <tableColumns>
-                                                        <tableColumn editable="NO" width="121" minWidth="16" maxWidth="1000" id="9Ld-M2-qQp" userLabel="Table Column - Image">
-                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="img header">
-                                                                <font key="font" metaFont="smallSystem"/>
-                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </tableHeaderCell>
-                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="Joh-9A-blp">
-                                                                <font key="font" metaFont="system"/>
-                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                            <prototypeCellViews>
-                                                                <tableCellView identifier="ImageCell" id="Zr3-Z6-MDj" customClass="RLMImageTableCellView">
-                                                                    <rect key="frame" x="1" y="1" width="121" height="17"/>
-                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                    <subviews>
-                                                                        <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xdo-Iu-B5b">
-                                                                            <rect key="frame" x="3" y="0.0" width="17" height="17"/>
-                                                                            <animations/>
-                                                                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSActionTemplate" id="RI4-MK-b13"/>
-                                                                        </imageView>
-                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oFu-wx-HHi">
-                                                                            <rect key="frame" x="25" y="0.0" width="92" height="17"/>
-                                                                            <animations/>
-                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="cell" id="rLS-h6-dI2">
-                                                                                <font key="font" metaFont="system"/>
-                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                    </subviews>
-                                                                    <animations/>
-                                                                    <connections>
-                                                                        <outlet property="imageView" destination="Xdo-Iu-B5b" id="h97-mK-0zd"/>
-                                                                        <outlet property="textField" destination="oFu-wx-HHi" id="nl5-ye-yK4"/>
-                                                                    </connections>
-                                                                </tableCellView>
-                                                            </prototypeCellViews>
-                                                        </tableColumn>
-                                                        <tableColumn editable="NO" width="120" minWidth="16" maxWidth="1000" id="j4J-kL-c21" userLabel="Table Column - Badge">
-                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="badge header">
-                                                                <font key="font" metaFont="smallSystem"/>
-                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </tableHeaderCell>
-                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="0UD-k1-665">
-                                                                <font key="font" metaFont="system"/>
-                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                            <prototypeCellViews>
-                                                                <customView identifier="BadgeCell" id="Hd5-t2-1T1" userLabel="BadgeCellView" customClass="RLMBadgeTableCellView">
-                                                                    <rect key="frame" x="125" y="1" width="120" height="22"/>
-                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                                                    <subviews>
-                                                                        <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cVi-ab-it6">
-                                                                            <rect key="frame" x="1" y="3" width="88" height="17"/>
-                                                                            <animations/>
-                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="badge" id="wJ3-zo-4Dq">
-                                                                                <font key="font" metaFont="system"/>
-                                                                                <color key="textColor" name="selectedMenuItemColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <button hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="OXI-nk-7Bf" userLabel="Badge - Instance count">
-                                                                            <rect key="frame" x="97" y="2" width="20" height="17"/>
-                                                                            <animations/>
-                                                                            <buttonCell key="cell" type="inline" title="i" bezelStyle="inline" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="EIT-dd-wAA">
-                                                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                                <font key="font" metaFont="smallSystemBold"/>
-                                                                            </buttonCell>
-                                                                        </button>
-                                                                    </subviews>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="trailing" secondItem="OXI-nk-7Bf" secondAttribute="trailing" constant="3" id="KOJ-Vi-k3I"/>
-                                                                        <constraint firstItem="OXI-nk-7Bf" firstAttribute="leading" secondItem="cVi-ab-it6" secondAttribute="trailing" constant="10" id="O6Y-96-Mjz"/>
-                                                                        <constraint firstItem="OXI-nk-7Bf" firstAttribute="centerY" secondItem="Hd5-t2-1T1" secondAttribute="centerY" id="aAO-JX-XV2"/>
-                                                                        <constraint firstItem="cVi-ab-it6" firstAttribute="leading" secondItem="Hd5-t2-1T1" secondAttribute="leading" constant="3" id="foH-PE-gH2"/>
-                                                                        <constraint firstItem="cVi-ab-it6" firstAttribute="centerY" secondItem="Hd5-t2-1T1" secondAttribute="centerY" id="iEb-Bu-FDU"/>
-                                                                    </constraints>
-                                                                    <animations/>
-                                                                    <connections>
-                                                                        <outlet property="badge" destination="OXI-nk-7Bf" id="eee-fx-a7w"/>
-                                                                        <outlet property="textField" destination="cVi-ab-it6" id="Pgq-bu-24o"/>
-                                                                    </connections>
-                                                                </customView>
-                                                            </prototypeCellViews>
-                                                        </tableColumn>
-                                                        <tableColumn editable="NO" width="100" minWidth="16" maxWidth="1000" id="HB0-rO-9fP" userLabel="Table Column - Basic">
-                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                <font key="font" metaFont="smallSystem"/>
-                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </tableHeaderCell>
-                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="bpk-7t-H7I">
-                                                                <font key="font" metaFont="system"/>
-                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                            <prototypeCellViews>
-                                                                <customView identifier="BasicCell" horizontalHuggingPriority="750" id="j4I-rB-nX0" userLabel="BasicCellView" customClass="RLMBasicTableCellView">
-                                                                    <rect key="frame" x="248" y="1" width="100" height="22"/>
-                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                                                    <subviews>
-                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="93e-Tp-EKj" customClass="RLMTextField">
-                                                                            <rect key="frame" x="1" y="3" width="98" height="17"/>
-                                                                            <animations/>
-                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" title="basic" id="qpt-2p-N69">
-                                                                                <font key="font" metaFont="system"/>
-                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                <connections>
-                                                                                    <action selector="editedTextField:" target="X01-Pz-1Ve" id="iSV-NZ-VV9"/>
-                                                                                </connections>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                    </subviews>
-                                                                    <constraints>
-                                                                        <constraint firstItem="93e-Tp-EKj" firstAttribute="trailing" secondItem="j4I-rB-nX0" secondAttribute="trailing" constant="-3" id="YNh-kk-Bcd"/>
-                                                                        <constraint firstItem="93e-Tp-EKj" firstAttribute="leading" secondItem="j4I-rB-nX0" secondAttribute="leading" constant="3" id="gYm-ox-cbv"/>
-                                                                        <constraint firstItem="93e-Tp-EKj" firstAttribute="centerY" secondItem="j4I-rB-nX0" secondAttribute="centerY" id="vSa-N8-zcA"/>
-                                                                    </constraints>
-                                                                    <animations/>
-                                                                    <connections>
-                                                                        <outlet property="textField" destination="93e-Tp-EKj" id="Tnb-25-h1b"/>
-                                                                    </connections>
-                                                                </customView>
-                                                            </prototypeCellViews>
-                                                        </tableColumn>
-                                                        <tableColumn editable="NO" width="100" minWidth="16" maxWidth="1000" id="pWT-Pu-eoh" userLabel="Table Column - Link">
-                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                <font key="font" metaFont="smallSystem"/>
-                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </tableHeaderCell>
-                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="5a6-EV-O7g">
-                                                                <font key="font" metaFont="system"/>
-                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                            <prototypeCellViews>
-                                                                <customView identifier="LinkCell" id="YQI-Ni-2Mh" userLabel="LinkCellView" customClass="RLMLinkTableCellView">
-                                                                    <rect key="frame" x="351" y="1" width="100" height="22"/>
-                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                                                    <subviews>
-                                                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r8V-o9-EUV" userLabel="Text Field - link" customClass="RLMTextField">
-                                                                            <rect key="frame" x="3" y="3" width="86" height="17"/>
-                                                                            <animations/>
-                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" title="link" id="HL4-Zf-clm">
-                                                                                <font key="font" metaFont="system"/>
-                                                                                <color key="textColor" red="0.21354569837895854" green="0.066052594969780221" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                <connections>
-                                                                                    <action selector="editedTextField:" target="X01-Pz-1Ve" id="iUZ-Lj-nww"/>
-                                                                                </connections>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                    </subviews>
-                                                                    <animations/>
-                                                                    <connections>
-                                                                        <outlet property="textField" destination="r8V-o9-EUV" id="Akr-mV-uxo"/>
-                                                                    </connections>
-                                                                </customView>
-                                                            </prototypeCellViews>
-                                                        </tableColumn>
-                                                        <tableColumn editable="NO" width="100" minWidth="16" maxWidth="1000" id="NOQ-Wf-6Bi" userLabel="Table Column - Index">
-                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                <font key="font" metaFont="smallSystem"/>
-                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </tableHeaderCell>
-                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="bFz-ck-XF7">
-                                                                <font key="font" metaFont="system"/>
-                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                            <prototypeCellViews>
-                                                                <customView identifier="IndexCell" id="ZNR-iz-CVh" userLabel="BasicCellView" customClass="RLMBasicTableCellView">
-                                                                    <rect key="frame" x="454" y="1" width="100" height="22"/>
-                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                                                    <subviews>
-                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="lDM-i2-eT3">
-                                                                            <rect key="frame" x="1" y="4" width="98" height="14"/>
-                                                                            <animations/>
-                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="right" title="index" usesSingleLineMode="YES" id="Iwz-HM-iW2">
-                                                                                <font key="font" metaFont="smallSystem"/>
-                                                                                <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                    </subviews>
-                                                                    <constraints>
-                                                                        <constraint firstItem="lDM-i2-eT3" firstAttribute="trailing" secondItem="ZNR-iz-CVh" secondAttribute="trailing" constant="-3" id="ZsI-Lt-nzu"/>
-                                                                        <constraint firstItem="lDM-i2-eT3" firstAttribute="leading" secondItem="ZNR-iz-CVh" secondAttribute="leading" constant="3" id="gCe-iP-7Pt"/>
-                                                                        <constraint firstItem="lDM-i2-eT3" firstAttribute="centerY" secondItem="ZNR-iz-CVh" secondAttribute="centerY" id="hrL-BM-3eu"/>
-                                                                    </constraints>
-                                                                    <animations/>
-                                                                    <connections>
-                                                                        <outlet property="textField" destination="lDM-i2-eT3" id="hhS-Bf-N7P"/>
-                                                                    </connections>
-                                                                </customView>
-                                                            </prototypeCellViews>
-                                                        </tableColumn>
-                                                        <tableColumn editable="NO" width="100" minWidth="16" maxWidth="1000" id="m5Y-Na-sqX" userLabel="Table Column - Number">
-                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                <font key="font" metaFont="smallSystem"/>
-                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </tableHeaderCell>
-                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="uS9-5J-zMl">
-                                                                <font key="font" metaFont="system"/>
-                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                            <prototypeCellViews>
-                                                                <customView identifier="NumberCell" id="Gj6-W6-FXj" userLabel="NumberCellView" customClass="RLMNumberTableCellView">
-                                                                    <rect key="frame" x="557" y="1" width="100" height="22"/>
-                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                                                    <subviews>
-                                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="OBR-LJ-wHt" customClass="RLMNumberTextField">
-                                                                            <rect key="frame" x="1" y="3" width="98" height="17"/>
-                                                                            <animations/>
-                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="right" title="number" usesSingleLineMode="YES" id="yDh-qQ-3JX">
-                                                                                <font key="font" metaFont="system"/>
-                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                <allowedInputSourceLocales>
-                                                                                    <string>NSAllRomanInputSourcesLocaleIdentifier</string>
-                                                                                </allowedInputSourceLocales>
-                                                                                <connections>
-                                                                                    <action selector="editedTextField:" target="X01-Pz-1Ve" id="tmu-uE-wVX"/>
-                                                                                </connections>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                    </subviews>
-                                                                    <constraints>
-                                                                        <constraint firstItem="OBR-LJ-wHt" firstAttribute="trailing" secondItem="Gj6-W6-FXj" secondAttribute="trailing" constant="-3" id="Cv1-2o-sDW"/>
-                                                                        <constraint firstItem="OBR-LJ-wHt" firstAttribute="centerY" secondItem="Gj6-W6-FXj" secondAttribute="centerY" id="hZZ-Ad-1Hx"/>
-                                                                        <constraint firstItem="OBR-LJ-wHt" firstAttribute="leading" secondItem="Gj6-W6-FXj" secondAttribute="leading" constant="3" id="vly-l7-PKg"/>
-                                                                    </constraints>
-                                                                    <animations/>
-                                                                    <connections>
-                                                                        <outlet property="textField" destination="OBR-LJ-wHt" id="lXR-p5-Ve9"/>
-                                                                    </connections>
-                                                                </customView>
-                                                            </prototypeCellViews>
-                                                        </tableColumn>
-                                                        <tableColumn editable="NO" width="256" minWidth="16" maxWidth="1000" id="7Rw-Va-X1A" userLabel="Table Column - Bool">
-                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                <font key="font" metaFont="smallSystem"/>
-                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </tableHeaderCell>
-                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="Zru-8r-Omw">
-                                                                <font key="font" metaFont="system"/>
-                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                            <prototypeCellViews>
-                                                                <customView identifier="BoolCell" id="sLz-cM-Sl8" userLabel="BoolCellView" customClass="RLMBoolTableCellView">
-                                                                    <rect key="frame" x="660" y="1" width="86" height="22"/>
-                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                                                    <subviews>
-                                                                        <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CbB-PG-BtE">
-                                                                            <rect key="frame" x="32" y="2" width="22" height="18"/>
-                                                                            <animations/>
-                                                                            <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="center" state="on" inset="2" id="WbG-3D-fJz">
-                                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                                                <font key="font" metaFont="system"/>
-                                                                                <connections>
-                                                                                    <action selector="editedCheckBox:" target="X01-Pz-1Ve" id="ZeK-bL-tNc"/>
-                                                                                </connections>
-                                                                            </buttonCell>
-                                                                        </button>
-                                                                    </subviews>
-                                                                    <constraints>
-                                                                        <constraint firstItem="CbB-PG-BtE" firstAttribute="centerX" secondItem="sLz-cM-Sl8" secondAttribute="centerX" id="9LF-nP-KbT"/>
-                                                                        <constraint firstItem="CbB-PG-BtE" firstAttribute="centerY" secondItem="sLz-cM-Sl8" secondAttribute="centerY" id="y4o-ES-IsK"/>
-                                                                    </constraints>
-                                                                    <animations/>
-                                                                    <connections>
-                                                                        <outlet property="checkBox" destination="CbB-PG-BtE" id="XE1-35-AhP"/>
-                                                                    </connections>
-                                                                </customView>
-                                                            </prototypeCellViews>
-                                                        </tableColumn>
-                                                    </tableColumns>
-                                                    <connections>
-                                                        <outlet property="dataSource" destination="X01-Pz-1Ve" id="GhO-Zd-xr8"/>
-                                                        <outlet property="delegate" destination="X01-Pz-1Ve" id="FW0-Gv-Asq"/>
-                                                    </connections>
-                                                </tableView>
-                                            </subviews>
-                                            <animations/>
-                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                        </clipView>
-                                        <animations/>
-                                        <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="4Ib-5w-NOS">
-                                            <rect key="frame" x="0.0" y="548" width="740" height="16"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <animations/>
-                                        </scroller>
-                                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="PKq-wN-eoD">
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <animations/>
-                                        </scroller>
-                                        <tableHeaderView key="headerView" id="cDp-e2-1cA">
-                                            <rect key="frame" x="0.0" y="0.0" width="918" height="23"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <animations/>
-                                        </tableHeaderView>
-                                    </scrollView>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="3b6-BA-X5L" secondAttribute="trailing" id="MsK-Hb-mbv"/>
-                                    <constraint firstItem="3b6-BA-X5L" firstAttribute="top" secondItem="XsG-4h-zWh" secondAttribute="top" id="Pzf-27-fXl"/>
-                                    <constraint firstAttribute="bottom" secondItem="3b6-BA-X5L" secondAttribute="bottom" id="VzH-qT-268"/>
-                                    <constraint firstItem="3b6-BA-X5L" firstAttribute="leading" secondItem="XsG-4h-zWh" secondAttribute="leading" id="tHS-lc-oSF"/>
-                                </constraints>
                                 <animations/>
                             </customView>
                         </subviews>
@@ -518,9 +171,6 @@
                                     <segment image="NSRightFacingTriangleTemplate" width="32" tag="1"/>
                                 </segments>
                             </segmentedCell>
-                            <connections>
-                                <action selector="userClicksOnNavigationButtons:" target="-2" id="xPX-We-2xd"/>
-                            </connections>
                         </segmentedControl>
                     </toolbarItem>
                     <toolbarItem implicitItemIdentifier="AC5460F5-955D-48AD-8697-2FA153F25F71" label="" paletteLabel="Search" id="iuT-AU-RcQ">
@@ -535,18 +185,11 @@
                                 <font key="font" metaFont="system"/>
                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                <connections>
-                                    <action selector="searchAction:" target="-2" id="hD2-Dg-6Pe"/>
-                                </connections>
                             </searchFieldCell>
                         </searchField>
                     </toolbarItem>
                     <toolbarItem implicitItemIdentifier="NSToolbarFlexibleSpaceItem" id="IBE-aS-65q"/>
-                    <toolbarItem implicitItemIdentifier="B1EB8F69-D4C8-4B21-B606-A54812FDD83C" explicitItemIdentifier="RealmLockItem" label="Realm" paletteLabel="Realm" toolTip="Lock to prevent editing" tag="1" image="RealmUnlocked" id="L8G-EJ-A1Z">
-                        <connections>
-                            <action selector="userClickedLockRealm:" target="-2" id="4PX-6Z-zko"/>
-                        </connections>
-                    </toolbarItem>
+                    <toolbarItem implicitItemIdentifier="B1EB8F69-D4C8-4B21-B606-A54812FDD83C" explicitItemIdentifier="RealmLockItem" label="Realm" paletteLabel="Realm" toolTip="Lock to prevent editing" tag="1" image="RealmUnlocked" id="L8G-EJ-A1Z"/>
                 </allowedToolbarItems>
                 <defaultToolbarItems>
                     <toolbarItem reference="dAe-mG-eMX"/>
@@ -555,27 +198,27 @@
                     <toolbarItem reference="iuT-AU-RcQ"/>
                 </defaultToolbarItems>
             </toolbar>
+            <contentBorderThickness minY="22"/>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-x8E"/>
             </connections>
-            <point key="canvasLocation" x="420.5" y="343"/>
+            <point key="canvasLocation" x="406.5" y="239"/>
         </window>
+        <viewController id="YNN-iB-ywJ" customClass="RLMRealmViewController">
+            <connections>
+                <outlet property="document" destination="-2" id="uKc-oz-WRg"/>
+                <outlet property="view" destination="XsG-4h-zWh" id="x7h-Jb-PTe"/>
+            </connections>
+        </viewController>
         <customObject id="hSp-0t-Gbg" customClass="RLMTypeOutlineViewController">
             <connections>
-                <outlet property="classesOutlineView" destination="IMi-6Y-gQF" id="inH-pi-Hwr"/>
-                <outlet property="parentWindowController" destination="-2" id="UwQ-DI-ttX"/>
+                <outlet property="document" destination="-2" id="JBc-wg-lC8"/>
+                <outlet property="outlineView" destination="IMi-6Y-gQF" id="mgl-Fy-ots"/>
                 <outlet property="view" destination="IMi-6Y-gQF" id="XQa-PV-Ysa"/>
-            </connections>
-        </customObject>
-        <customObject id="X01-Pz-1Ve" customClass="RLMInstanceTableViewController">
-            <connections>
-                <outlet property="parentWindowController" destination="-2" id="zrl-bi-GWW"/>
-                <outlet property="view" destination="enp-HN-e6b" id="ve8-y2-M62"/>
             </connections>
         </customObject>
     </objects>
     <resources>
-        <image name="NSActionTemplate" width="14" height="14"/>
         <image name="NSLeftFacingTriangleTemplate" width="9" height="12"/>
         <image name="NSRightFacingTriangleTemplate" width="9" height="12"/>
         <image name="RealmUnlocked" width="32" height="32"/>

--- a/RealmBrowser/Base.lproj/RLMTableViewController.xib
+++ b/RealmBrowser/Base.lproj/RLMTableViewController.xib
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9046" systemVersion="14F1017" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9046"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="RLMTableViewController">
+            <connections>
+                <outlet property="arrayController" destination="MW0-ku-Rhp" id="PFp-cC-SoL"/>
+                <outlet property="tableView" destination="6zF-se-iee" id="PzN-Rv-cnM"/>
+                <outlet property="view" destination="QUO-hJ-rKh" id="UIz-IC-s8s"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <scrollView wantsLayer="YES" autohidesScrollers="YES" horizontalLineScroll="24" horizontalPageScroll="10" verticalLineScroll="24" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="QUO-hJ-rKh">
+            <rect key="frame" x="0.0" y="0.0" width="387" height="265"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <clipView key="contentView" id="wbC-IP-NhL">
+                <rect key="frame" x="1" y="17" width="385" height="247"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                <subviews>
+                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" rowHeight="22" rowSizeStyle="automatic" headerView="s8A-VC-4DG" viewBased="YES" floatsGroupRows="NO" id="6zF-se-iee">
+                        <rect key="frame" x="0.0" y="0.0" width="385" height="247"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <size key="intercellSpacing" width="3" height="2"/>
+                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        <tableViewGridLines key="gridStyleMask" vertical="YES" horizontal="YES"/>
+                        <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                        <tableColumns>
+                            <tableColumn width="382" minWidth="40" maxWidth="1000" id="c2P-UE-Mws">
+                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                    <font key="font" metaFont="smallSystem"/>
+                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                </tableHeaderCell>
+                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="GNl-sw-uw3">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                <prototypeCellViews>
+                                    <tableCellView identifier="ImageCell" id="vGC-Qz-eUj" customClass="RLMImageTableCellView">
+                                        <rect key="frame" x="1" y="1" width="382" height="17"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <subviews>
+                                            <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="juq-eO-2Mv">
+                                                <rect key="frame" x="3" y="0.0" width="17" height="17"/>
+                                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSActionTemplate" id="hzk-ck-CWg"/>
+                                            </imageView>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oP3-ct-kQk">
+                                                <rect key="frame" x="25" y="0.0" width="92" height="17"/>
+                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="cell" id="1GX-hK-0uE">
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                        </subviews>
+                                        <connections>
+                                            <outlet property="imageView" destination="juq-eO-2Mv" id="Rei-PT-P0I"/>
+                                            <outlet property="textField" destination="oP3-ct-kQk" id="8xo-Ax-VVd"/>
+                                        </connections>
+                                    </tableCellView>
+                                    <customView identifier="BadgeCell" id="lbB-1R-79U" userLabel="BadgeCellView" customClass="RLMBadgeTableCellView">
+                                        <rect key="frame" x="1" y="20" width="382" height="22"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                        <subviews>
+                                            <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sq3-H9-dGs">
+                                                <rect key="frame" x="1" y="3" width="350" height="17"/>
+                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="badge" id="4b8-A2-Fo3">
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" name="selectedMenuItemColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                            <button hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="hya-kX-ixN" userLabel="Badge - Instance count">
+                                                <rect key="frame" x="359" y="2" width="20" height="17"/>
+                                                <buttonCell key="cell" type="inline" title="i" bezelStyle="inline" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ep0-7Q-ZN3">
+                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" metaFont="smallSystemBold"/>
+                                                </buttonCell>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="hya-kX-ixN" firstAttribute="centerY" secondItem="lbB-1R-79U" secondAttribute="centerY" id="BwE-Cg-n1Y"/>
+                                            <constraint firstItem="Sq3-H9-dGs" firstAttribute="centerY" secondItem="lbB-1R-79U" secondAttribute="centerY" id="Pbz-mx-fzE"/>
+                                            <constraint firstItem="hya-kX-ixN" firstAttribute="leading" secondItem="Sq3-H9-dGs" secondAttribute="trailing" constant="10" id="UeG-Aw-YxS"/>
+                                            <constraint firstAttribute="trailing" secondItem="hya-kX-ixN" secondAttribute="trailing" constant="3" id="ffg-fI-XIr"/>
+                                            <constraint firstItem="Sq3-H9-dGs" firstAttribute="leading" secondItem="lbB-1R-79U" secondAttribute="leading" constant="3" id="gQj-PZ-Hrd"/>
+                                        </constraints>
+                                        <connections>
+                                            <outlet property="badge" destination="hya-kX-ixN" id="iUB-uX-kat"/>
+                                            <outlet property="textField" destination="Sq3-H9-dGs" id="T56-e5-0Er"/>
+                                        </connections>
+                                    </customView>
+                                    <customView identifier="BasicCell" horizontalHuggingPriority="750" id="37N-lb-i3e" userLabel="BasicCellView" customClass="RLMBasicTableCellView">
+                                        <rect key="frame" x="1" y="44" width="382" height="22"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                        <subviews>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="nRL-zJ-7WY" customClass="RLMTextField">
+                                                <rect key="frame" x="1" y="3" width="386" height="17"/>
+                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" title="basic" id="7JY-C3-qDE">
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="nRL-zJ-7WY" firstAttribute="trailing" secondItem="37N-lb-i3e" secondAttribute="trailing" constant="3" id="6eb-Jx-CTd"/>
+                                            <constraint firstItem="nRL-zJ-7WY" firstAttribute="centerY" secondItem="37N-lb-i3e" secondAttribute="centerY" id="jNY-fA-KOy"/>
+                                            <constraint firstItem="nRL-zJ-7WY" firstAttribute="leading" secondItem="37N-lb-i3e" secondAttribute="leading" constant="3" id="mWY-E2-0bf"/>
+                                        </constraints>
+                                        <connections>
+                                            <outlet property="textField" destination="nRL-zJ-7WY" id="fT4-ec-Kg8"/>
+                                        </connections>
+                                    </customView>
+                                    <customView identifier="LinkCell" id="WPZ-jh-bZU" userLabel="LinkCellView" customClass="RLMLinkTableCellView">
+                                        <rect key="frame" x="1" y="68" width="382" height="22"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                        <subviews>
+                                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tQ1-sC-wgl" userLabel="Text Field - link" customClass="RLMTextField">
+                                                <rect key="frame" x="3" y="3" width="86" height="17"/>
+                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" title="link" id="Hbe-US-ACk">
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" red="0.21354569840000001" green="0.066052594970000003" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                        </subviews>
+                                        <connections>
+                                            <outlet property="textField" destination="tQ1-sC-wgl" id="1ph-fb-JBC"/>
+                                        </connections>
+                                    </customView>
+                                    <customView identifier="IndexCell" id="32f-38-cHI" userLabel="BasicCellView" customClass="RLMBasicTableCellView">
+                                        <rect key="frame" x="1" y="92" width="382" height="22"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                        <subviews>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="6gU-mb-F2H">
+                                                <rect key="frame" x="1" y="4" width="380" height="14"/>
+                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="right" title="index" usesSingleLineMode="YES" id="Wyr-HC-ckv">
+                                                    <font key="font" metaFont="smallSystem"/>
+                                                    <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="6gU-mb-F2H" firstAttribute="leading" secondItem="32f-38-cHI" secondAttribute="leading" constant="3" id="VJr-gm-tHx"/>
+                                            <constraint firstItem="6gU-mb-F2H" firstAttribute="centerY" secondItem="32f-38-cHI" secondAttribute="centerY" id="cqt-CW-a7W"/>
+                                            <constraint firstItem="6gU-mb-F2H" firstAttribute="trailing" secondItem="32f-38-cHI" secondAttribute="trailing" constant="-3" id="ksK-81-XEc"/>
+                                        </constraints>
+                                        <connections>
+                                            <outlet property="textField" destination="6gU-mb-F2H" id="DpU-hg-4iT"/>
+                                        </connections>
+                                    </customView>
+                                    <customView identifier="NumberCell" id="Jnv-PW-ycs" userLabel="NumberCellView" customClass="RLMNumberTableCellView">
+                                        <rect key="frame" x="1" y="116" width="382" height="22"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                        <subviews>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Kq5-tS-XVv" customClass="RLMNumberTextField">
+                                                <rect key="frame" x="1" y="3" width="380" height="17"/>
+                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="right" title="number" usesSingleLineMode="YES" id="PwY-Ow-nAV">
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    <allowedInputSourceLocales>
+                                                        <string>NSAllRomanInputSourcesLocaleIdentifier</string>
+                                                    </allowedInputSourceLocales>
+                                                </textFieldCell>
+                                            </textField>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="Kq5-tS-XVv" firstAttribute="centerY" secondItem="Jnv-PW-ycs" secondAttribute="centerY" id="A2U-uF-KJt"/>
+                                            <constraint firstItem="Kq5-tS-XVv" firstAttribute="trailing" secondItem="Jnv-PW-ycs" secondAttribute="trailing" constant="-3" id="NGO-Ge-vg1"/>
+                                            <constraint firstItem="Kq5-tS-XVv" firstAttribute="leading" secondItem="Jnv-PW-ycs" secondAttribute="leading" constant="3" id="Py0-cE-eWb"/>
+                                        </constraints>
+                                        <connections>
+                                            <outlet property="textField" destination="Kq5-tS-XVv" id="9OG-HS-Ywi"/>
+                                        </connections>
+                                    </customView>
+                                    <customView identifier="BoolCell" id="6kj-2i-hDK" userLabel="BoolCellView" customClass="RLMBoolTableCellView">
+                                        <rect key="frame" x="1" y="140" width="382" height="22"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                        <subviews>
+                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="luW-rX-NZA">
+                                                <rect key="frame" x="180" y="2" width="22" height="18"/>
+                                                <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="center" state="on" inset="2" id="an5-H4-qKP">
+                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                </buttonCell>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="luW-rX-NZA" firstAttribute="centerX" secondItem="6kj-2i-hDK" secondAttribute="centerX" id="Gfo-Wo-jIY"/>
+                                            <constraint firstItem="luW-rX-NZA" firstAttribute="centerY" secondItem="6kj-2i-hDK" secondAttribute="centerY" id="K03-VI-nqp"/>
+                                        </constraints>
+                                        <connections>
+                                            <outlet property="checkBox" destination="luW-rX-NZA" id="mQs-cb-eAn"/>
+                                        </connections>
+                                    </customView>
+                                    <tableCellView identifier="cell" id="HXc-wc-yUl">
+                                        <rect key="frame" x="1" y="164" width="382" height="17"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <subviews>
+                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7do-ON-4hU">
+                                                <rect key="frame" x="0.0" y="0.0" width="100" height="17"/>
+                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Ui9-01-Nux">
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                        </subviews>
+                                        <connections>
+                                            <outlet property="textField" destination="7do-ON-4hU" id="9Ye-pl-Us9"/>
+                                        </connections>
+                                    </tableCellView>
+                                </prototypeCellViews>
+                            </tableColumn>
+                        </tableColumns>
+                        <connections>
+                            <outlet property="delegate" destination="-2" id="sag-gM-YF4"/>
+                        </connections>
+                    </tableView>
+                </subviews>
+                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+            </clipView>
+            <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="JV1-Rl-bE6">
+                <rect key="frame" x="1" y="119" width="223" height="15"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </scroller>
+            <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="CEd-yy-k4x">
+                <rect key="frame" x="224" y="17" width="15" height="102"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </scroller>
+            <tableHeaderView key="headerView" id="s8A-VC-4DG">
+                <rect key="frame" x="0.0" y="0.0" width="385" height="17"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableHeaderView>
+            <point key="canvasLocation" x="367.5" y="545.5"/>
+        </scrollView>
+        <arrayController objectClassName="RLMObject" preservesSelection="NO" avoidsEmptySelection="NO" id="MW0-ku-Rhp"/>
+    </objects>
+    <resources>
+        <image name="NSActionTemplate" width="14" height="14"/>
+    </resources>
+</document>

--- a/RealmBrowser/Base.lproj/RLMTableViewController.xib
+++ b/RealmBrowser/Base.lproj/RLMTableViewController.xib
@@ -21,8 +21,8 @@
                 <rect key="frame" x="1" y="17" width="385" height="247"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
-                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" rowHeight="22" rowSizeStyle="automatic" headerView="s8A-VC-4DG" viewBased="YES" floatsGroupRows="NO" id="6zF-se-iee">
-                        <rect key="frame" x="0.0" y="0.0" width="385" height="247"/>
+                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveColumns="NO" rowHeight="22" rowSizeStyle="automatic" headerView="s8A-VC-4DG" viewBased="YES" floatsGroupRows="NO" id="6zF-se-iee">
+                        <rect key="frame" x="0.0" y="0.0" width="385" height="0.0"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <size key="intercellSpacing" width="3" height="2"/>
                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/RealmBrowser/Classes/RLMBadgeTableCellView.m
+++ b/RealmBrowser/Classes/RLMBadgeTableCellView.m
@@ -19,4 +19,5 @@
 #import "RLMBadgeTableCellView.h"
 
 @implementation RLMBadgeTableCellView
+
 @end

--- a/RealmBrowser/Classes/RLMDescriptions.m
+++ b/RealmBrowser/Classes/RLMDescriptions.m
@@ -18,7 +18,7 @@
 
 #import "RLMDescriptions.h"
 
-#import "RLMRealmBrowserWindowController.h"
+//#import "RLMRealmBrowserWindowController.h"
 #import "RLMArrayNavigationState.h"
 #import "RLMQueryNavigationState.h"
 #import "RLMArrayNode.h"

--- a/RealmBrowser/Classes/RLMDocument.h
+++ b/RealmBrowser/Classes/RLMDocument.h
@@ -22,6 +22,9 @@
 
 @interface RLMDocument : NSDocument
 
+@property (nonatomic, readonly) RLMRealm *realm;
+@property (nonatomic, strong) RLMObjectSchema *selectedObjectSchema;
+
 @property (nonatomic, readonly) BOOL potentiallyEncrypted;
 @property (nonatomic, strong) IBOutlet RLMRealmNode *presentedRealm;
 

--- a/RealmBrowser/Classes/RLMDocument.m
+++ b/RealmBrowser/Classes/RLMDocument.m
@@ -18,11 +18,14 @@
 
 #import "RLMDocument.h"
 
+@import Realm;
+
+#import "RLMRealmNode.h"
 #import "RLMClassNode.h"
 #import "RLMArrayNode.h"
 #import "RLMClassProperty.h"
 #import "RLMRealmOutlineNode.h"
-#import "RLMRealmBrowserWindowController.h"
+//#import "RLMRealmBrowserWindowController.h"
 #import "RLMAlert.h"
 
 #import <AppSandboxFileAccess/AppSandboxFileAccess.h>
@@ -100,19 +103,20 @@
                 }
                     
                 ws.presentedRealm  = realmNode;
+                _realm = realmNode.realm;
                 
-                ws.changeNotificationToken = [realmNode.realm addNotificationBlock:^(NSString *notification, RLMRealm *realm) {
-                    for (RLMRealmBrowserWindowController *windowController in ws.windowControllers) {
-                        [windowController reloadAfterEdit];
-                    }
-                }];
+//                ws.changeNotificationToken = [realmNode.realm addNotificationBlock:^(NSString *notification, RLMRealm *realm) {
+//                    for (RLMRealmBrowserWindowController *windowController in ws.windowControllers) {
+//                        [windowController reloadAfterEdit];
+//                    }
+//                }];
                 
                 NSDocumentController *documentController = [NSDocumentController sharedDocumentController];
                 [documentController noteNewRecentDocumentURL:absoluteURL];
                 
-                for (RLMRealmBrowserWindowController *windowController in ws.windowControllers) {
-                    [windowController realmDidLoad];
-                }
+//                for (RLMRealmBrowserWindowController *windowController in ws.windowControllers) {
+//                    [windowController realmDidLoad];
+//                }
                 
                 success = YES;
             }
@@ -148,13 +152,6 @@
 }
 
 #pragma mark - Public methods - NSDocument overrides - Creating and Managing Window Controllers
-
-- (void)makeWindowControllers
-{
-    RLMRealmBrowserWindowController *windowController = [[RLMRealmBrowserWindowController alloc] initWithWindowNibName:self.windowNibName];
-    windowController.modelDocument = self;
-    [self addWindowController:windowController];
-}
 
 - (NSString *)windowNibName
 {

--- a/RealmBrowser/Classes/RLMInstanceTableViewController.h
+++ b/RealmBrowser/Classes/RLMInstanceTableViewController.h
@@ -21,11 +21,13 @@
 #import "RLMViewController.h"
 #import "RLMTableView.h"
 #import "RLMTextField.h"
+#import "RLMDocument.h"
 
-@class RLMRealmBrowserWindowController;
 @class RLMArrayNode;
 
 @interface RLMInstanceTableViewController : RLMViewController <RLMTextFieldDelegate, RLMTableViewDelegate, RLMTableViewDataSource>
+
+@property (weak) IBOutlet RLMDocument *document;
 
 @property (nonatomic, readonly) RLMTableView *realmTableView;
 

--- a/RealmBrowser/Classes/RLMInstanceTableViewController.m
+++ b/RealmBrowser/Classes/RLMInstanceTableViewController.m
@@ -20,7 +20,7 @@
 @import Foundation;
 @import Realm.Dynamic;
 
-#import "RLMRealmBrowserWindowController.h"
+//#import "RLMRealmBrowserWindowController.h"
 #import "RLMObjectLinkSelectionViewController.h"
 #import "RLMArrayNavigationState.h"
 #import "RLMQueryNavigationState.h"
@@ -109,7 +109,7 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     
     [self.tableView setAutosaveTableColumns:NO];
     
-    RLMRealm *realm = self.parentWindowController.modelDocument.presentedRealm.realm;
+    RLMRealm *realm;// = self.parentWindowController.modelDocument.presentedRealm.realm;
     
     if ([newState isMemberOfClass:[RLMNavigationState class]]) {
         self.displayedType = newState.selectedType;
@@ -213,7 +213,7 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
         [self moveRowsInRealmFrom:rowIndexes to:destination];
 
         // Performs the move visually in all relevant windows
-        [self.parentWindowController moveRowsInTableViewForArrayNode:(RLMArrayNode *)self.displayedType from:rowIndexes to:destination];
+//        [self.parentWindowController moveRowsInTableViewForArrayNode:(RLMArrayNode *)self.displayedType from:rowIndexes to:destination];
         
         return YES;
     }
@@ -228,8 +228,8 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     numberFormatter.maximumFractionDigits = 3;
 
     // For certain types we want to add some statistics
-    RLMPropertyType type = propertyColumn.property.type;
-    NSString *propertyName = propertyColumn.property.name;
+    RLMPropertyType type;// = propertyColumn.property.type;
+    NSString *propertyName;// = propertyColumn.property.name;
     
     if (![self.displayedType isKindOfClass:[RLMClassNode class]]) {
         return nil;
@@ -272,11 +272,11 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 {
     if (self.tableView == notification.object) {
         NSInteger selectedIndex = self.tableView.selectedRow;
-        [self.parentWindowController.currentState updateSelectionToIndex:selectedIndex];
+//        [self.parentWindowController.currentState updateSelectionToIndex:selectedIndex];
         
         if (self.didSelectedBlock != nil) {
             RLMObject *selectedInstance = [self.displayedType instanceAtIndex:selectedIndex];
-            self.didSelectedBlock(selectedInstance);
+//            self.didSelectedBlock(selectedInstance);
         }
     }
 }
@@ -429,23 +429,23 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 - (void)deleteObjects:(NSIndexSet *)rowIndexes
 {
     [self deleteObjectsInRealmAtIndexes:rowIndexes];
-    [self.parentWindowController reloadAllWindows];
+//    [self.parentWindowController reloadAllWindows];
 }
 
 - (void)addNewObjects:(NSIndexSet *)rowIndexes
 {
-    RLMRealm *realm = self.parentWindowController.modelDocument.presentedRealm.realm;
+    RLMRealm *realm;// = self.parentWindowController.modelDocument.presentedRealm.realm;
     NSUInteger objectCount = MAX(rowIndexes.count, 1);
 
     RLMObject *newObject;
     
     [realm beginWriteTransaction];
     for (NSUInteger i = 0; i < objectCount; i++) {
-        newObject = [self.class createObjectInRealm:realm withSchema:self.displayedType.schema];
+//        newObject = [self.class createObjectInRealm:realm withSchema:self.displayedType.schema];
     }
     [realm commitWriteTransaction];
     
-    [self.parentWindowController reloadAllWindows];
+//    [self.parentWindowController reloadAllWindows];
     
     if (newObject && [self.displayedType isKindOfClass:RLMClassNode.class]) {
         RLMClassNode *classNode = (RLMClassNode *)self.displayedType;
@@ -458,19 +458,19 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 - (void)removeRows:(NSIndexSet *)rowIndexes
 {
     [self removeRowsInRealmAt:rowIndexes];
-    [self.parentWindowController removeRowsInTableViewForArrayNode:(RLMArrayNode *)self.displayedType at:rowIndexes];
+//    [self.parentWindowController removeRowsInTableViewForArrayNode:(RLMArrayNode *)self.displayedType at:rowIndexes];
 }
 
 - (void)deleteRows:(NSIndexSet *)rowIndexes
 {
     [self deleteRowsInRealmAt:rowIndexes];
-    [self.parentWindowController deleteRowsInTableViewForArrayNode:(RLMArrayNode *)self.displayedType at:rowIndexes];
+//    [self.parentWindowController deleteRowsInTableViewForArrayNode:(RLMArrayNode *)self.displayedType at:rowIndexes];
 }
 
 - (void)addNewRows:(NSIndexSet *)rowIndexes
 {
     [self insertNewRowsInRealmAt:rowIndexes];
-    [self.parentWindowController insertNewRowsInTableViewForArrayNode:(RLMArrayNode *)self.displayedType at:rowIndexes];
+//    [self.parentWindowController insertNewRowsInTableViewForArrayNode:(RLMArrayNode *)self.displayedType at:rowIndexes];
 }
 
 // Operations on links in cells
@@ -481,12 +481,12 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     popover.contentViewController = popoverContent;
     popover.behavior = NSPopoverBehaviorTransient;
     
-    NSArray *topLevelClasses = self.parentWindowController.modelDocument.presentedRealm.topLevelClasses;
+    NSArray *topLevelClasses;// = self.parentWindowController.modelDocument.presentedRealm.topLevelClasses;
     
     RLMObject *selectedInstance = [self.displayedType instanceAtIndex:rowIndexes.firstIndex];
     NSInteger propertyIndex = [self propertyIndexForColumn:columnIndex];
     
-    RLMRealm *realm = self.parentWindowController.modelDocument.presentedRealm.realm;
+    RLMRealm *realm;// = self.parentWindowController.modelDocument.presentedRealm.realm;
     RLMObjectSchema *objectSchema = [realm.schema schemaForClassName:self.displayedType.name];
     RLMProperty *property = objectSchema.properties[propertyIndex];
     
@@ -500,7 +500,7 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     __weak typeof(popover) weakPopover = popover;
     
     popoverContent.didSelectedBlock = ^(RLMObject *object) {
-        RLMRealm *realm = weakSelf.parentWindowController.modelDocument.presentedRealm.realm;
+        RLMRealm *realm;// = weakSelf.parentWindowController.modelDocument.presentedRealm.realm;
         [realm beginWriteTransaction];
         
         selectedInstance[property.name] = object;
@@ -528,12 +528,12 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 {
     NSInteger propertyIndex = [self propertyIndexForColumn:column];
     RLMClassProperty *propertyNode = self.displayedType.propertyColumns[propertyIndex];
-    RLMArrayNavigationState *state = [[RLMArrayNavigationState alloc] initWithSelectedType:self.displayedType
-                                                                                 typeIndex:row
-                                                                                  property:propertyNode.property
-                                                                                arrayIndex:0];
+//    RLMArrayNavigationState *state = [[RLMArrayNavigationState alloc] initWithSelectedType:self.displayedType
+//                                                                                 typeIndex:row
+//                                                                                  property:propertyNode.property
+//                                                                                arrayIndex:0];
     
-    [self.parentWindowController newWindowWithNavigationState:state];
+//    [self.parentWindowController newWindowWithNavigationState:state];
 }
 
 #pragma mark - Private Methods - RLMTableView Delegate Helpers
@@ -630,7 +630,7 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 {
     NSInteger propertyIndex = [self propertyIndexForColumn:column];
 
-    RLMRealm *realm = self.parentWindowController.modelDocument.presentedRealm.realm;
+    RLMRealm *realm;// = self.parentWindowController.modelDocument.presentedRealm.realm;
     RLMObjectSchema *objectSchema = [realm.schema schemaForClassName:self.displayedType.name];
     RLMProperty *property = objectSchema.properties[propertyIndex];
     
@@ -659,13 +659,13 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 {
     NSInteger propertyIndex = [self propertyIndexForColumn:column];
     
-    RLMRealm *realm = self.parentWindowController.modelDocument.presentedRealm.realm;
+    RLMRealm *realm;// = self.parentWindowController.modelDocument.presentedRealm.realm;
     RLMClassProperty *classProperty = self.displayedType.propertyColumns[propertyIndex];
     
     id newValue = [NSNull null];
-    if (classProperty.property.type == RLMPropertyTypeArray) {
-        newValue = @[];
-    }
+//    if (classProperty.property.type == RLMPropertyTypeArray) {
+//        newValue = @[];
+//    }
     
     [realm beginWriteTransaction];
     [rowIndexes enumerateIndexesUsingBlock:^(NSUInteger rowIndex, BOOL *stop) {
@@ -674,7 +674,7 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     }];
     [realm commitWriteTransaction];
     
-    [self.parentWindowController reloadAllWindows];
+//    [self.parentWindowController reloadAllWindows];
 }
 
 #pragma mark - Rearranging objects in arrays - Private methods
@@ -682,7 +682,7 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 // Removing
 - (void)removeRowsInRealmAt:(NSIndexSet *)rowIndexes
 {
-    RLMRealm *realm = self.parentWindowController.modelDocument.presentedRealm.realm;
+    RLMRealm *realm;// = self.parentWindowController.modelDocument.presentedRealm.realm;
     
     [realm beginWriteTransaction];
     [rowIndexes enumerateIndexesWithOptions:NSEnumerationReverse usingBlock:^(NSUInteger index, BOOL *stop) {
@@ -714,14 +714,14 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
         rowIndexes = [NSIndexSet indexSetWithIndex:0];
     }
     
-    RLMRealm *realm = self.parentWindowController.modelDocument.presentedRealm.realm;
+    RLMRealm *realm;// = self.parentWindowController.modelDocument.presentedRealm.realm;
     
     [realm beginWriteTransaction];
     
     [rowIndexes enumerateRangesWithOptions:NSEnumerationReverse usingBlock:^(NSRange range, BOOL *stop) {
         for (NSUInteger i = range.location; i < NSMaxRange(range); i++) {
-            RLMObject *object = [self.class createObjectInRealm:realm withSchema:self.displayedType.schema];
-            [(RLMArrayNode *)self.displayedType insertInstance:object atIndex:range.location];
+//            RLMObject *object = [self.class createObjectInRealm:realm withSchema:self.displayedType.schema];
+//            [(RLMArrayNode *)self.displayedType insertInstance:object atIndex:range.location];
         }
     }];
     
@@ -748,7 +748,7 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 // Moving
 - (void)moveRowsInRealmFrom:(NSIndexSet *)sourceIndexes to:(NSUInteger)destination
 {
-    RLMRealm *realm = self.parentWindowController.modelDocument.presentedRealm.realm;
+    RLMRealm *realm;// = self.parentWindowController.modelDocument.presentedRealm.realm;
     
     NSMutableArray *sources = [self arrayWithIndexSet:sourceIndexes];
     
@@ -807,7 +807,7 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 
 - (void)deleteObjectsInRealmAtIndexes:(NSIndexSet *)rowIndexes
 {
-    RLMRealm *realm = self.parentWindowController.modelDocument.presentedRealm.realm;
+    RLMRealm *realm;// = self.parentWindowController.modelDocument.presentedRealm.realm;
     
     NSMutableArray *objectsToDelete = [NSMutableArray array];
     [rowIndexes enumerateIndexesUsingBlock:^(NSUInteger index, BOOL *stop) {
@@ -935,13 +935,13 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     }
     
     if (result) {
-        RLMRealm *realm = self.parentWindowController.modelDocument.presentedRealm.realm;
+        RLMRealm *realm;// = self.parentWindowController.modelDocument.presentedRealm.realm;
         [realm beginWriteTransaction];
         selectedInstance[propertyNode.name] = result;
         [realm commitWriteTransaction];
     }
     
-    [self.parentWindowController reloadAllWindows];
+//    [self.parentWindowController reloadAllWindows];
 }
 
 - (IBAction)editedCheckBox:(NSButton *)sender
@@ -956,12 +956,12 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 
     NSNumber *result = @((BOOL)(sender.state == NSOnState));
 
-    RLMRealm *realm = self.parentWindowController.modelDocument.presentedRealm.realm;
+    RLMRealm *realm;// = self.parentWindowController.modelDocument.presentedRealm.realm;
     [realm beginWriteTransaction];
     selectedInstance[propertyNode.name] = result;
     [realm commitWriteTransaction];
     
-    [self.parentWindowController reloadAllWindows];
+//    [self.parentWindowController reloadAllWindows];
 }
 
 - (void)rightClickedLocation:(RLMTableLocation)location
@@ -1004,17 +1004,17 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
             RLMObject *linkedObject = (RLMObject *)propertyValue;
             RLMObjectSchema *linkedObjectSchema = linkedObject.objectSchema;
             
-            for (RLMClassNode *classNode in self.parentWindowController.modelDocument.presentedRealm.topLevelClasses) {
-                if ([classNode.name isEqualToString:linkedObjectSchema.className]) {
-                    RLMResults *allInstances = [linkedObject.realm allObjects:linkedObjectSchema.className];
-                    NSUInteger objectIndex = [allInstances indexOfObject:linkedObject];
-                    
-                    RLMNavigationState *state = [[RLMNavigationState alloc] initWithSelectedType:classNode index:objectIndex];
-                    [self.parentWindowController addNavigationState:state fromViewController:self];
-                    
-                    break;
-                }
-            }
+//            for (RLMClassNode *classNode in self.parentWindowController.modelDocument.presentedRealm.topLevelClasses) {
+//                if ([classNode.name isEqualToString:linkedObjectSchema.className]) {
+//                    RLMResults *allInstances = [linkedObject.realm allObjects:linkedObjectSchema.className];
+//                    NSUInteger objectIndex = [allInstances indexOfObject:linkedObject];
+//                    
+//                    RLMNavigationState *state = [[RLMNavigationState alloc] initWithSelectedType:classNode index:objectIndex];
+//                    [self.parentWindowController addNavigationState:state fromViewController:self];
+//                    
+//                    break;
+//                }
+//            }
         }
     }
     else if (propertyNode.type == RLMPropertyTypeArray) {
@@ -1022,11 +1022,11 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
         NSObject *propertyValue = selectedInstance[propertyNode.name];
         
         if ([propertyValue isKindOfClass:[RLMArray class]]) {
-            RLMArrayNavigationState *state = [[RLMArrayNavigationState alloc] initWithSelectedType:self.displayedType
-                                                                                         typeIndex:row
-                                                                                          property:propertyNode.property
-                                                                                        arrayIndex:0];
-            [self.parentWindowController addNavigationState:state fromViewController:self];
+//            RLMArrayNavigationState *state = [[RLMArrayNavigationState alloc] initWithSelectedType:self.displayedType
+//                                                                                         typeIndex:row
+//                                                                                          property:propertyNode.property
+//                                                                                        arrayIndex:0];
+//            [self.parentWindowController addNavigationState:state fromViewController:self];
         }
     }
     else {
@@ -1076,7 +1076,7 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
             [menu addItem:item];
             
             if ([menu popUpMenuPositioningItem:nil atLocation:frame.origin inView:self.tableView]) {
-                RLMRealm *realm = self.parentWindowController.modelDocument.presentedRealm.realm;
+                RLMRealm *realm;// = self.parentWindowController.modelDocument.presentedRealm.realm;
                 [realm beginWriteTransaction];
                 selectedObject[propertyNode.name] = datepicker.dateValue;
                 [realm commitWriteTransaction];

--- a/RealmBrowser/Classes/RLMRealmViewController.h
+++ b/RealmBrowser/Classes/RLMRealmViewController.h
@@ -1,0 +1,16 @@
+//
+//  RLMRealmViewController.h
+//  RealmBrowser
+//
+//  Created by Matt Bauer on 10/27/15.
+//  Copyright © 2015 Realm inc. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+#import "RLMDocument.h"
+
+@interface RLMRealmViewController : NSViewController
+
+@property (weak) IBOutlet RLMDocument *document;
+
+@end

--- a/RealmBrowser/Classes/RLMRealmViewController.m
+++ b/RealmBrowser/Classes/RLMRealmViewController.m
@@ -1,0 +1,64 @@
+//
+//  RLMRealmViewController.m
+//  RealmBrowser
+//
+//  Created by Matt Bauer on 10/27/15.
+//  Copyright © 2015 Realm inc. All rights reserved.
+//
+
+#import "RLMRealmViewController.h"
+#import "RLMTableViewController.h"
+
+@interface RLMRealmViewController ()
+
+@property (nonatomic, strong) NSMutableDictionary *objectSchemaTableViews;
+
+@end
+
+@implementation RLMRealmViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.objectSchemaTableViews = [NSMutableDictionary dictionary];
+    
+    [self.document addObserver:self forKeyPath:@"selectedObjectSchema" options:0 context:NULL];
+}
+
+- (void)dealloc
+{
+    [self.document removeObserver:self forKeyPath:@"selectedObjectSchema"];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *,id> *)change context:(void *)context
+{
+//    dispatch_async(dispatch_get_main_queue(), ^{
+        [self updateForSelectedObjectSchema];
+//    });
+}
+
+- (void)updateForSelectedObjectSchema
+{
+    [[[self.view subviews] firstObject] removeFromSuperview];
+    
+    RLMTableViewController *vc = self.objectSchemaTableViews[self.document.selectedObjectSchema.className];
+    
+    if (!vc) {
+        vc = [[RLMTableViewController alloc] initWithNibName:@"RLMTableViewController" bundle:nil];
+        [vc loadView];
+        [vc bind:@"document" toObject:self withKeyPath:@"document" options:nil];
+        [vc setObjectSchema:self.document.selectedObjectSchema];
+        self.objectSchemaTableViews[self.document.selectedObjectSchema.className] = vc;
+    }
+
+    NSView *view = vc.view;
+    [view setTranslatesAutoresizingMaskIntoConstraints:NO];
+    [self.view addSubview:view];
+    
+    NSDictionary *views = NSDictionaryOfVariableBindings(view);
+    
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[view]|" options:0 metrics:nil views:views]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[view]|" options:0 metrics:nil views:views]];    
+}
+
+@end

--- a/RealmBrowser/Classes/RLMResultsControllerArray.h
+++ b/RealmBrowser/Classes/RLMResultsControllerArray.h
@@ -1,0 +1,16 @@
+//
+//  RLMResultsControllerArray.h
+//  RealmBrowser
+//
+//  Created by Matt Bauer on 10/28/15.
+//  Copyright © 2015 Realm inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "RLMResultsController.h"
+
+@interface RLMResultsControllerArray : NSMutableArray
+
+- (instancetype)initWithController:(RLMResultsController *)controller;
+
+@end

--- a/RealmBrowser/Classes/RLMResultsControllerArray.m
+++ b/RealmBrowser/Classes/RLMResultsControllerArray.m
@@ -1,0 +1,261 @@
+//
+//  RLMResultsControllerArray.m
+//  RealmBrowser
+//
+//  Created by Matt Bauer on 10/28/15.
+//  Copyright © 2015 Realm inc. All rights reserved.
+//
+
+#import "RLMResultsControllerArray.h"
+#import "RLMResultsControllerObservationProxy.h"
+
+@implementation RLMResultsControllerArray {
+    NSMutableArray *_array;
+    NSMutableArray *_observationProxies;
+    NSMutableIndexSet *_roi;
+    RLMResultsController * _controller;
+}
+
+-objectAtIndex:(NSUInteger)idx {
+    return [_array objectAtIndex:idx];
+}
+
+-(NSUInteger)count {
+    return [_array count];
+}
+
+-init {
+    return [self initWithObjects:NULL count:0];
+}
+
+- (instancetype)initWithController:(RLMResultsController *)controller
+{
+    return [self init];
+}
+
+-initWithObjects:(id *)objects count:(NSUInteger)count {
+    _array=[[NSMutableArray alloc] initWithObjects:objects count:count];
+    _observationProxies=[NSMutableArray new];
+    return self;
+}
+
+-(void)dealloc {
+    if([_observationProxies count]>0)
+        [NSException raise:NSInvalidArgumentException format:@"_NSControllerArray still being observed by %@ on %@",
+         [[_observationProxies objectAtIndex:0] observer],[[_observationProxies objectAtIndex:0] keyPath]];
+}
+
+-(void)addObserver:(id)observer forKeyPath:(NSString*)keyPath options:(NSKeyValueObservingOptions)options context:(void*)context {
+    // init the proxy
+    RLMResultsControllerObservationProxy *proxy=[[RLMResultsControllerObservationProxy alloc] initWithKeyPath:keyPath observer:observer object:self];
+    
+    proxy->_options=options;
+    proxy->_context=context;
+    [_observationProxies addObject:proxy];
+    
+    // get the relevant indexes
+    id idxs;
+    if(_roi)
+        idxs=_roi;
+    else
+        idxs=[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, [_array count])];
+    
+    // is this an operator?
+    if([keyPath hasPrefix:@"@"])
+    {
+        NSString* firstPart, *rest;
+        NSStringKVCSplitOnDot(keyPath,&firstPart,&rest);
+        
+        // observe ourselves
+        [super addObserver:observer forKeyPath:keyPath options:options context:context];
+        
+        // if there's anything the operator depends on, observe _all_ objects for that path
+        keyPath=rest;
+        idxs=[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, [_array count])];
+    }
+    
+    // add observer proxy for all relevant indexes
+    if([_array count] && keyPath) {
+        [_array addObserver:proxy toObjectsAtIndexes:idxs forKeyPath:keyPath options:options context:context];
+    }
+}
+
+-(void)removeObserver:(id)observer forKeyPath:(NSString*)keyPath {
+    // find the proxy again
+    RLMResultsControllerObservationProxy *proxy=[[RLMResultsControllerObservationProxy alloc] initWithKeyPath:keyPath observer:observer object:self];
+    NSUInteger idx=[_observationProxies indexOfObject:proxy];
+    proxy=[_observationProxies objectAtIndex:idx];
+    [_observationProxies removeObjectAtIndex:idx];
+    
+    // get the relevant indexes
+    id idxs;
+    
+    if(_roi)
+        idxs=_roi;
+    else
+        idxs=[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, [_array count])];
+    
+    // operator?
+    if([keyPath hasPrefix:@"@"])
+    {
+        NSString* firstPart, *rest;
+        NSStringKVCSplitOnDot(keyPath,&firstPart,&rest);
+        
+        [super removeObserver:observer forKeyPath:keyPath];
+        
+        // remove dependent key path from all children
+        keyPath=rest;
+        idxs=[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, [_array count])];
+    }
+    if([_array count] && keyPath) {
+        [_array removeObserver:proxy fromObjectsAtIndexes:idxs forKeyPath:keyPath];
+    }
+}
+
+-(void)insertObject:(id)obj atIndex:(NSUInteger)idx
+{
+    for(RLMResultsControllerObservationProxy *proxy in _observationProxies)
+    {
+        id keyPath=[proxy keyPath];
+        
+        if([keyPath hasPrefix:@"@"]) {
+            // this operator will probably have changed
+            [self willChangeValueForKey:keyPath];
+            
+            NSString* firstPart, *rest;
+            NSStringKVCSplitOnDot(keyPath,&firstPart,&rest);
+            
+            // if dependencies: observe these in any case
+            if(rest)
+                [obj addObserver:proxy
+                      forKeyPath:rest
+                         options:[proxy options]
+                         context:[proxy context]];
+        }
+        else
+            if(!_roi) {
+                // only observe if no ROI
+                [obj addObserver:proxy
+                      forKeyPath:keyPath
+                         options:[proxy options]
+                         context:[proxy context]];
+            }
+    }
+    
+    [_array insertObject:obj atIndex:idx];
+    // change ROI to reflect new state (unobserved for new index)
+    [_roi shiftIndexesStartingAtIndex:idx by:1];
+    
+    for(RLMResultsControllerObservationProxy *proxy in _observationProxies)
+    {
+        id keyPath=[proxy keyPath];
+        
+        if([keyPath hasPrefix:@"@"])
+            [self didChangeValueForKey:keyPath];
+    }
+}
+
+-(void)removeObjectAtIndex:(NSUInteger)idx
+{
+    id obj=[_array objectAtIndex:idx];
+    for(RLMResultsControllerObservationProxy *proxy in _observationProxies)
+    {
+        id keyPath=[proxy keyPath];
+        
+        if([keyPath hasPrefix:@"@"]) {
+            [self willChangeValueForKey:keyPath];
+            NSString* firstPart, *rest;
+            NSStringKVCSplitOnDot(keyPath,&firstPart,&rest);
+            
+            if(rest) {
+                [obj removeObserver:proxy forKeyPath:rest];
+            }
+        }
+        else {
+            if(!_roi || [_roi containsIndex:idx]) {
+                [obj removeObserver:proxy forKeyPath:keyPath];
+            }
+        }
+    }
+    [_array removeObjectAtIndex:idx];
+    
+    if([_roi containsIndex:idx])
+        [_roi shiftIndexesStartingAtIndex:idx+1 by:-1];
+    
+    for(RLMResultsControllerObservationProxy *proxy in _observationProxies)
+    {
+        id keyPath=[proxy keyPath];
+        
+        if([keyPath hasPrefix:@"@"])
+            [self didChangeValueForKey:keyPath];
+    }
+}
+
+-(void)addObject:(id)obj {
+    [self insertObject:obj atIndex:[self count]];
+}
+
+-(void)removeLastObject {
+    [self removeObjectAtIndex:[self count]-1];
+}
+
+-(void)replaceObjectAtIndex:(NSUInteger)idx withObject:(id)obj
+{
+    id old=[_array objectAtIndex:idx];
+    for(RLMResultsControllerObservationProxy *proxy in _observationProxies)
+    {
+        id keyPath=[proxy keyPath];
+        
+        if([keyPath hasPrefix:@"@"]) {
+            [self willChangeValueForKey:keyPath];
+            NSString* firstPart, *rest;
+            NSStringKVCSplitOnDot(keyPath,&firstPart,&rest);
+            
+            if(rest) {
+                [old removeObserver:proxy forKeyPath:[proxy keyPath]];
+                
+                [obj addObserver:proxy
+                      forKeyPath:rest
+                         options:[proxy options]
+                         context:[proxy context]];
+            }
+        }
+        else {
+            if(!_roi || [_roi containsIndex:idx]) {
+                [old removeObserver:proxy forKeyPath:[proxy keyPath]];
+                
+                [obj addObserver:proxy
+                      forKeyPath:[proxy keyPath]
+                         options:[proxy options]
+                         context:[proxy context]];
+            }
+        }
+    }
+    [_array replaceObjectAtIndex:idx withObject:obj];
+    
+    for(RLMResultsControllerObservationProxy *proxy in _observationProxies)
+    {
+        id keyPath=[proxy keyPath];
+        
+        if([keyPath hasPrefix:@"@"])
+            [self didChangeValueForKey:keyPath];
+    }
+}
+
+-(void)setROI:(NSIndexSet*)newROI {
+    if(newROI != _roi) {
+        id proxies=[_observationProxies copy];
+        
+        // TODO: this should be optimized to only change those indexes that actually changed
+        for(RLMResultsControllerObservationProxy *proxy in proxies) {
+            [self removeObserver:[proxy observer] forKeyPath:[proxy keyPath]];
+        }
+        
+        _roi=[newROI mutableCopy];
+        
+        for(RLMResultsControllerObservationProxy *proxy in proxies) {
+            [self addObserver:[proxy observer] forKeyPath:[proxy keyPath] options:[proxy options] context:[proxy context]];
+        }
+    }
+}
+@end

--- a/RealmBrowser/Classes/RLMResultsControllerObservationProxy.h
+++ b/RealmBrowser/Classes/RLMResultsControllerObservationProxy.h
@@ -1,0 +1,30 @@
+//
+//  RLMResultsControllerObservationProxy.h
+//  RealmBrowser
+//
+//  Created by Matt Bauer on 10/28/15.
+//  Copyright © 2015 Realm inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface RLMResultsControllerObservationProxy : NSObject {
+    id _keyPath;
+    id _observer;
+    id _object;
+    BOOL _notifyObject;
+    // only as storage (context for _observer will be the one given in observeValueForKeyPath:)
+    // FIXME: write accessors, remove @public
+@public
+    void *_context;
+    NSKeyValueObservingOptions _options;
+}
+- initWithKeyPath:(NSString *)keyPath observer:(id)observer object:(id)object;
+- (id)observer;
+- (id)keyPath;
+- (void)setNotifyObject:(BOOL)val;
+- (void *)context;
+- (NSKeyValueObservingOptions)options;
+@end
+
+void NSStringKVCSplitOnDot(NSString *self, NSString **before, NSString **after);

--- a/RealmBrowser/Classes/RLMResultsControllerObservationProxy.m
+++ b/RealmBrowser/Classes/RLMResultsControllerObservationProxy.m
@@ -1,0 +1,79 @@
+//
+//  RLMResultsControllerObservationProxy.m
+//  RealmBrowser
+//
+//  Created by Matt Bauer on 10/28/15.
+//  Copyright © 2015 Realm inc. All rights reserved.
+//
+
+#import <objc/runtime.h>
+#import "RLMResultsControllerObservationProxy.h"
+
+void NSStringKVCSplitOnDot(NSString *self,NSString **before,NSString **after){
+    NSRange range=[self rangeOfString:@"."];
+    if(range.location!=NSNotFound)
+    {
+        *before=[self substringToIndex:range.location];
+        *after=[self substringFromIndex:range.location+1];
+    }
+    else
+    {
+        *before=self;
+        *after=nil;
+    }
+}
+
+@implementation RLMResultsControllerObservationProxy
+
+-initWithKeyPath:(NSString *)keyPath observer:(id)observer object:(id)object {
+    _keyPath=keyPath;
+    _observer=observer;
+    _object=object;
+    return self;
+}
+
+-observer {
+    return _observer;
+}
+
+-keyPath {
+    return _keyPath;
+}
+
+-(void *)context {
+    return _context;
+}
+
+-(NSKeyValueObservingOptions)options {
+    return _options;
+}
+
+-(void)setNotifyObject:(BOOL)val
+{
+    _notifyObject=val;
+}
+
+- (BOOL)isEqual:(id)other
+{
+    if([other isMemberOfClass:object_getClass(self)])
+    {
+        RLMResultsControllerObservationProxy *o=other;
+        if(o->_observer==_observer && [o->_keyPath isEqual:_keyPath] && [o->_object isEqual:_object])
+            return YES;
+    }
+    return NO;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
+    if(_notifyObject) {
+        [_object observeValueForKeyPath:_keyPath ofObject:_object change:change context:_context];
+    }
+    
+    [_observer observeValueForKeyPath:_keyPath ofObject:_object change:change context:_context];
+}
+
+-(NSString *)description {
+    return [NSString stringWithFormat:@"observation proxy for %@ on key path %@", _observer, _keyPath];
+}
+
+@end

--- a/RealmBrowser/Classes/RLMTableRowView.h
+++ b/RealmBrowser/Classes/RLMTableRowView.h
@@ -1,0 +1,13 @@
+//
+//  RLMTableRowView.h
+//  RealmBrowser
+//
+//  Created by Matt Bauer on 10/27/15.
+//  Copyright © 2015 Realm inc. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface RLMTableRowView : NSTableRowView
+
+@end

--- a/RealmBrowser/Classes/RLMTableRowView.m
+++ b/RealmBrowser/Classes/RLMTableRowView.m
@@ -1,0 +1,18 @@
+//
+//  RLMTableRowView.m
+//  RealmBrowser
+//
+//  Created by Matt Bauer on 10/27/15.
+//  Copyright © 2015 Realm inc. All rights reserved.
+//
+
+#import "RLMTableRowView.h"
+
+@implementation RLMTableRowView
+
+- (BOOL)isOpaque
+{
+    return YES;
+}
+
+@end

--- a/RealmBrowser/Classes/RLMTableViewController.h
+++ b/RealmBrowser/Classes/RLMTableViewController.h
@@ -1,0 +1,21 @@
+//
+//  RLMTableViewController.h
+//  RealmBrowser
+//
+//  Created by Matt Bauer on 10/27/15.
+//  Copyright © 2015 Realm inc. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+#import "RLMDocument.h"
+#import "RLMResultsController.h"
+
+@interface RLMTableViewController : NSViewController <NSTableViewDelegate>
+
+@property (weak) IBOutlet NSTableView * tableView;
+@property (weak) IBOutlet NSArrayController * arrayController;
+
+@property (nonatomic, strong) RLMDocument * document;
+@property (nonatomic, strong) RLMObjectSchema * objectSchema;
+
+@end

--- a/RealmBrowser/Classes/RLMTableViewController.m
+++ b/RealmBrowser/Classes/RLMTableViewController.m
@@ -1,0 +1,142 @@
+//
+//  RLMTableViewController.m
+//  RealmBrowser
+//
+//  Created by Matt Bauer on 10/27/15.
+//  Copyright © 2015 Realm inc. All rights reserved.
+//
+
+#import "RLMTableViewController.h"
+#import "RLMBadgeTableCellView.h"
+#import "RLMBasicTableCellView.h"
+#import "RLMBoolTableCellView.h"
+#import "RLMNumberTableCellView.h"
+#import "RLMImageTableCellView.h"
+#import "RLMTableRowView.h"
+
+@import Realm.Dynamic;
+
+@interface RLMTableViewController ()
+
+@end
+
+@implementation RLMTableViewController
+
+- (void)setDocument:(RLMDocument *)document
+{
+    [self willChangeValueForKey:@"document"];
+    _document = document;
+    [self didChangeValueForKey:@"document"];
+}
+
+- (void)setObjectSchema:(RLMObjectSchema *)objectSchema
+{
+    [self willChangeValueForKey:@"objectSchema"];
+    _objectSchema = objectSchema;
+    [self didChangeValueForKey:@"objectSchema"];
+
+    for (RLMObject *o in [self.document.realm allObjects:[_objectSchema className]]) {
+        [(NSArrayController *)self.arrayController addObject:o];
+    }
+
+    [self.tableView beginUpdates];
+ 
+    [self.tableView removeTableColumn:[self.tableView.tableColumns lastObject]];
+
+    for (RLMProperty * property in _objectSchema.properties) {
+        NSTableColumn *tableColumn = [[NSTableColumn alloc] initWithIdentifier:property.name];
+        tableColumn.title = property.name;
+        [tableColumn setResizingMask:NSTableColumnAutoresizingMask|NSTableColumnUserResizingMask];
+        [tableColumn bind:NSValueBinding toObject:self.arrayController withKeyPath:[NSString stringWithFormat:@"arrangedObjects.%@", property.name] options:nil];
+        [self.tableView addTableColumn:tableColumn];
+    }
+    
+    [self.tableView endUpdates];
+}
+
+- (NSTableRowView *)tableView:(NSTableView *)tableView rowViewForRow:(NSInteger)row
+{
+    RLMTableRowView *rowView = [tableView makeViewWithIdentifier:@"rlmrow" owner:self];
+    
+    if (!rowView) {
+        rowView = [[RLMTableRowView alloc] initWithFrame:NSZeroRect];
+        rowView.identifier = @"rlmrow";
+//        rowView.canDrawSubviewsIntoLayer = YES;
+    }
+
+    return rowView;
+}
+
+- (NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row
+{
+    RLMProperty * property = [self.document.selectedObjectSchema objectForKeyedSubscript:tableColumn.identifier];
+    
+    switch (property.type) {
+        case RLMPropertyTypeInt: {
+            RLMNumberTableCellView *view = [tableView makeViewWithIdentifier:@"NumberCell" owner:self];
+            [view.textField bind:NSValueBinding toObject:view withKeyPath:[NSString stringWithFormat:@"objectValue.%@", tableColumn.identifier] options:nil];
+            return view;
+        }
+
+        case RLMPropertyTypeBool: {
+            RLMBoolTableCellView *view = [tableView makeViewWithIdentifier:@"BoolCell" owner:self];
+            [view.checkBox bind:NSValueBinding toObject:view withKeyPath:[NSString stringWithFormat:@"objectValue.%@", tableColumn.identifier] options:nil];
+            return view;
+        }
+
+        case RLMPropertyTypeFloat: {
+            RLMNumberTableCellView *view = [tableView makeViewWithIdentifier:@"NumberCell" owner:self];
+            [view.textField bind:NSValueBinding toObject:view withKeyPath:[NSString stringWithFormat:@"objectValue.%@", tableColumn.identifier] options:nil];
+            return view;
+        }
+
+        case RLMPropertyTypeDouble: {
+            RLMNumberTableCellView *view = [tableView makeViewWithIdentifier:@"NumberCell" owner:self];
+            [view.textField bind:NSValueBinding toObject:view withKeyPath:[NSString stringWithFormat:@"objectValue.%@", tableColumn.identifier] options:nil];
+            return view;
+        }
+
+        case RLMPropertyTypeString: {
+            RLMBasicTableCellView *view = [tableView makeViewWithIdentifier:@"BasicCell" owner:self];
+            [view.textField bind:NSValueBinding toObject:view withKeyPath:[NSString stringWithFormat:@"objectValue.%@", tableColumn.identifier] options:nil];
+            return view;
+        }
+
+        case RLMPropertyTypeData: {
+            RLMBasicTableCellView *view = [tableView makeViewWithIdentifier:@"BasicCell" owner:self];
+            [view.textField bind:NSValueBinding toObject:view withKeyPath:[NSString stringWithFormat:@"objectValue.%@", tableColumn.identifier] options:nil];
+            return view;
+        }
+
+        case RLMPropertyTypeAny: {
+            RLMBasicTableCellView *view = [tableView makeViewWithIdentifier:@"BasicCell" owner:self];
+            [view.textField bind:NSValueBinding toObject:view withKeyPath:[NSString stringWithFormat:@"objectValue.%@", tableColumn.identifier] options:nil];
+            return view;
+        }
+
+        case RLMPropertyTypeDate: {
+            RLMBasicTableCellView *view = [tableView makeViewWithIdentifier:@"BasicCell" owner:self];
+            [view.textField bind:NSValueBinding toObject:view withKeyPath:[NSString stringWithFormat:@"objectValue.%@", tableColumn.identifier] options:nil];
+            return view;
+        }
+
+        case RLMPropertyTypeObject: {
+            RLMLinkTableCellView *view = [tableView makeViewWithIdentifier:@"LinkCell" owner:self];
+//            [view.textField bind:NSValueBinding toObject:view withKeyPath:[NSString stringWithFormat:@"objectValue.%@", tableColumn.identifier] options:nil];
+            return view;
+        }
+            
+        case RLMPropertyTypeArray: {
+            RLMBadgeTableCellView *view = [tableView makeViewWithIdentifier:@"BadgeCell" owner:self];
+//            [view.textField bind:NSValueBinding toObject:view withKeyPath:[NSString stringWithFormat:@"objectValue.%@", tableColumn.identifier] options:nil];
+            return view;
+        }
+            
+        default:
+            break;
+    }
+
+    return nil;
+}
+
+@end

--- a/RealmBrowser/Classes/RLMTypeOutlineViewController.h
+++ b/RealmBrowser/Classes/RLMTypeOutlineViewController.h
@@ -18,9 +18,11 @@
 
 @import Cocoa;
 
-#import "RLMViewController.h"
-#import "RLMClassNode.h"
+#import "RLMDocument.h"
 
-@interface RLMTypeOutlineViewController : RLMViewController <NSOutlineViewDataSource, NSOutlineViewDelegate>
+@interface RLMTypeOutlineViewController : NSViewController <NSOutlineViewDataSource, NSOutlineViewDelegate>
+
+@property (weak) IBOutlet NSOutlineView *outlineView;
+@property (weak) IBOutlet RLMDocument *document;
 
 @end

--- a/RealmBrowser/RLMObjectLinkSelectionViewController.xib
+++ b/RealmBrowser/RLMObjectLinkSelectionViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="MacOSX.Cocoa" propertyAccessControl="all" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9046" systemVersion="14F1017" targetRuntime="MacOSX.Cocoa" propertyAccessControl="all" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9059"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9046"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="RLMObjectLinkSelectionViewController">

--- a/RealmBrowser/RLMResultsController.h
+++ b/RealmBrowser/RLMResultsController.h
@@ -1,0 +1,13 @@
+//
+//  RLMResultsController.h
+//  RealmBrowser
+//
+//  Created by Matt Bauer on 10/26/15.
+//  Copyright © 2015 Realm inc. All rights reserved.
+//
+
+@import Cocoa;
+
+@interface RLMResultsController : NSArrayController
+
+@end

--- a/RealmBrowser/RLMResultsController.m
+++ b/RealmBrowser/RLMResultsController.m
@@ -1,0 +1,52 @@
+//
+//  RLMResultsController.m
+//  RealmBrowser
+//
+//  Created by Matt Bauer on 10/26/15.
+//  Copyright © 2015 Realm inc. All rights reserved.
+//
+
+#import "RLMResultsController.h"
+#import "RLMResultsControllerArray.h"
+
+@import Realm.Dynamic;
+
+@implementation RLMResultsController {
+    RLMResultsControllerArray *_arrangedObjects;
+}
+
+#pragma mark - Lifecycle
+
+- (nonnull instancetype)initWithContent:(nullable id)content
+{
+    if (self = [super initWithContent:content]) {
+        [self configure];
+    }
+    
+    return self;
+}
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)coder
+{
+    if (self = [super initWithCoder:coder]) {
+        [self configure];
+    }
+    
+    return self;
+}
+
+- (nonnull id)arrangedObjects
+{
+    return _arrangedObjects;
+}
+
+#pragma mark - Private
+
+- (void)configure
+{
+    [self willChangeValueForKey: @"arrangedObjects"];
+    _arrangedObjects = [[RLMResultsControllerArray alloc] initWithController:self];
+    [self didChangeValueForKey: @"arrangedObjects"];
+}
+
+@end

--- a/RealmBrowser/RealmBrowser-Info.plist
+++ b/RealmBrowser/RealmBrowser-Info.plist
@@ -42,7 +42,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>317</string>
+	<string>322</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/RealmBrowser/RealmBrowser-Info.plist
+++ b/RealmBrowser/RealmBrowser-Info.plist
@@ -42,7 +42,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>39</string>
+	<string>317</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
With this work I was trying to remove all the display model classes the app has right now and much of the complex logic in the view controllers. My plan was to defer until the last possible moment reading in the data from Realm to display. I could do that with a custom NSArrayController. The NSArrayController would also handle the adding/removing/changing of rows/value too. This would remove much of the code in RLMInstanceTableViewController. I also changed the sidebar to be a much lighter weight NSOutlineView. My plan with that is to allow objects (rows) to be dragged into it for quick reference back as their is no way to keep track of interesting objects right now. The app had an window controller but it really doesn’t need one. I replaced it with a view controller that ties the sidebar with the main table view. For each table/class a unique tableview and NSArrayController are created. This makes switching back and forth between tables/classes very fast. Overall these changes removed a lot of code that was written (thought I haven’t deleted the files yet in the branch) and reduced the memory footprint by half or more.