### PR TITLE
Improve scrolling performance a little

### DIFF
--- a/RealmBrowser/Base.lproj/RLMDocument.xib
+++ b/RealmBrowser/Base.lproj/RLMDocument.xib
@@ -148,7 +148,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="740" height="476"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" alternatingRowBackgroundColors="YES" autosaveName="InstanceTable" rowHeight="18" headerView="cDp-e2-1cA" viewBased="YES" id="enp-HN-e6b" customClass="RLMTableView">
+                                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="sequential" alternatingRowBackgroundColors="YES" autosaveName="InstanceTable" rowHeight="18" headerView="cDp-e2-1cA" viewBased="YES" id="enp-HN-e6b" customClass="RLMTableView">
                                                     <rect key="frame" x="0.0" y="0.0" width="918" height="0.0"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>

--- a/RealmBrowser/Base.lproj/RLMDocument.xib
+++ b/RealmBrowser/Base.lproj/RLMDocument.xib
@@ -142,7 +142,7 @@
                                 <rect key="frame" x="237" y="0.0" width="740" height="476"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <subviews>
-                                    <scrollView focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="20" horizontalPageScroll="10" verticalLineScroll="20" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3b6-BA-X5L" userLabel="MainScroll">
+                                    <scrollView wantsLayer="YES" focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="20" horizontalPageScroll="10" verticalLineScroll="20" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3b6-BA-X5L" userLabel="MainScroll">
                                         <rect key="frame" x="0.0" y="0.0" width="740" height="476"/>
                                         <clipView key="contentView" focusRingType="none" id="kRO-aN-FFM">
                                             <rect key="frame" x="0.0" y="0.0" width="740" height="476"/>

--- a/RealmBrowser/Classes/RLMInstanceTableViewController.m
+++ b/RealmBrowser/Classes/RLMInstanceTableViewController.m
@@ -362,11 +362,11 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
             RLMNumberTableCellView *numberCellView = [tableView makeViewWithIdentifier:@"xNumberCell" owner:self];
             if (!numberCellView) {
                 numberCellView = [RLMNumberTableCellView makeWithIdentifier:@"xNumberCell"];
+                numberCellView.textField.delegate = self;
             }
 
             numberCellView.textField.stringValue = [realmDescriptions printablePropertyValue:propertyValue ofType:type];
-            numberCellView.textField.delegate = self;
-            
+
             ((RLMNumberTextField *)numberCellView.textField).number = propertyValue;
             numberCellView.textField.editable = !self.realmIsLocked;
             
@@ -398,9 +398,9 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
             RLMBasicTableCellView *basicCellView = [tableView makeViewWithIdentifier:@"xBasicCell" owner:self];
             if (!basicCellView) {
                 basicCellView = [RLMBasicTableCellView makeWithIdentifier:@"xBasicCell"];
+                basicCellView.textField.delegate = self;
             }
             basicCellView.textField.stringValue = [realmDescriptions printablePropertyValue:propertyValue ofType:type];
-            basicCellView.textField.delegate = self;
             basicCellView.textField.editable = !self.realmIsLocked && type != RLMPropertyTypeData;
             
             cellView = basicCellView;


### PR DESCRIPTION
Mark the table view's scroll view as layer backed, and moves some table cell view initialization so it only runs when a cell view is created rather than every time a cell view is requested.

This change moves the bottleneck from drawing to layout. The result is that most scrolling takes place at over 50 fps in my testing. With extremely aggressive scrolling it's possible to get the framerate to drop when the amount of layout work exceeds the time the main thread has available between frames.

/cc @TimOliver 