### PR TITLE
Refactored format checker code to use RLMRealmConfiguration

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Realm:
-    :commit: 0b41680ee87252bf5222c22f6dadc400119e6893
+    :commit: 89339a8ec4f5ff7622299e4cec42a7f70f9c8066
     :git: https://github.com/realm/realm-cocoa.git
 
 SPEC CHECKSUMS:

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Realm:
-    :commit: 0b41680ee87252bf5222c22f6dadc400119e6893
+    :commit: 89339a8ec4f5ff7622299e4cec42a7f70f9c8066
     :git: https://github.com/realm/realm-cocoa.git
 
 SPEC CHECKSUMS:

--- a/Pods/Realm/Realm/RLMRealm.mm
+++ b/Pods/Realm/Realm/RLMRealm.mm
@@ -189,30 +189,6 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
     return [RLMRealm realmWithConfiguration:configuration error:outError];
 }
 
-+ (instancetype)realmWithPath:(NSString *)path
-                          key:(NSData *)key
-                     readOnly:(BOOL)readonly
-                     inMemory:(BOOL)inMemory
-                      dynamic:(BOOL)dynamic
-                       schema:(RLMSchema *)customSchema
-         disableFormatUpgrade:(BOOL)disableFormatUpgrade
-                        error:(NSError *__autoreleasing *)outError
-{
-    RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
-    if (inMemory) {
-        configuration.inMemoryIdentifier = path.lastPathComponent;
-    }
-    else {
-        configuration.path = path;
-    }
-    configuration.encryptionKey = key;
-    configuration.readOnly = readonly;
-    configuration.dynamic = dynamic;
-    configuration.customSchema = customSchema;
-    configuration.disableFormatUpgrade = disableFormatUpgrade;
-    return [RLMRealm realmWithConfiguration:configuration error:outError];
-}
-
 // ARC tries to eliminate calls to autorelease when the value is then immediately
 // returned, but this results in significantly different semantics between debug
 // and release builds for RLMRealm, so force it to always autorelease.

--- a/Pods/Realm/include/realm/RLMRealm_Private.h
+++ b/Pods/Realm/include/realm/RLMRealm_Private.h
@@ -69,44 +69,6 @@ FOUNDATION_EXTERN NSData *RLMRealmValidatedEncryptionKey(NSData *key);
                        schema:(RLMSchema *)customSchema
                         error:(NSError **)outError;
 
-/**
- This method is useful only in specialized circumstances, for example, when opening Realm files
- retrieved externally that contain a different schema than defined in your application.
- If you are simply building an app on Realm you should consider using:
- [defaultRealm]([RLMRealm defaultRealm]) or [realmWithPath:]([RLMRealm realmWithPath:])
- 
- Obtains an `RLMRealm` instance with persistence to a specific file path with
- options.
- 
- @warning This method is useful only in specialized circumstances.
- 
- @param path                    Path to the file you want the data saved in.
- @param key                     64-byte key to use to encrypt the data.
- @param readonly                `BOOL` indicating if this Realm is read-only (must use for read-only files)
- @param inMemory                `BOOL` indicating if this Realm is in-memory
- @param dynamic                 `BOOL` indicating if this Realm is dynamic
- @param customSchema            `RLMSchema` object representing the schema for the Realm
- @param disableFormatUpgrade    Whether Realm may upgrade this files format version if required
- @param outError                If an error occurs, upon return contains an `NSError` object
- that describes the problem. If you are not interested in
- possible errors, pass in NULL.
- 
- @return An `RLMRealm` instance.
- 
- @see RLMRealm defaultRealm
- @see RLMRealm realmWithPath:
- @see RLMRealm realmWithPath:readOnly:error:
- @see RLMRealm realmWithPath:encryptionKey:readOnly:error:
- */
-+ (instancetype)realmWithPath:(NSString *)path
-                          key:(NSData *)key
-                     readOnly:(BOOL)readonly
-                     inMemory:(BOOL)inMemory
-                      dynamic:(BOOL)dynamic
-                       schema:(RLMSchema *)customSchema
-         disableFormatUpgrade:(BOOL)disableFormatUpgrade
-                        error:(NSError **)outError;
-
 - (void)registerEnumerator:(RLMFastEnumerator *)enumerator;
 - (void)unregisterEnumerator:(RLMFastEnumerator *)enumerator;
 

--- a/RealmBrowser/Classes/RLMEncryptionKeyWindowController.m
+++ b/RealmBrowser/Classes/RLMEncryptionKeyWindowController.m
@@ -76,14 +76,12 @@
 {
     NSError *error = nil;
     @autoreleasepool {
-        [RLMRealm realmWithPath:self.realmFilePath.path
-                                     key:keyData
-                                readOnly:NO
-                                inMemory:NO
-                                 dynamic:YES
-                                  schema:nil
-                    disableFormatUpgrade:YES
-                                   error:&error];
+        RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
+        configuration.disableFormatUpgrade = YES;
+        configuration.dynamic = YES;
+        configuration.encryptionKey = keyData;
+        configuration.path = self.realmFilePath.path;
+        [RLMRealm realmWithConfiguration:configuration error:&error];
     }
     
     //If an error is thrown, it can either mean the encryption key was incorrect,

--- a/RealmBrowser/Classes/RLMRealmNode.m
+++ b/RealmBrowser/Classes/RLMRealmNode.m
@@ -91,14 +91,13 @@
 - (BOOL)realmFileRequiresFormatUpgrade
 {
     NSError *localError;
-    [RLMRealm realmWithPath:_url
-                      key:self.encryptionKey
-                 readOnly:NO
-                 inMemory:NO
-                  dynamic:YES
-                   schema:nil
-     disableFormatUpgrade:YES
-                    error:&localError];
+    
+    RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
+    configuration.disableFormatUpgrade = YES;
+    configuration.dynamic = YES;
+    configuration.encryptionKey = self.encryptionKey;
+    configuration.path = _url;
+    [RLMRealm realmWithConfiguration:configuration error:&localError];
     
     if (localError && localError.code == RLMErrorFileFormatUpgradeRequired) {
         return YES;


### PR DESCRIPTION
As part of refactoring the Realm Cocoa integration, the Browser now relies on `RLMRealmConfiguration` directly instead of the previous wrapper method.