### PR TITLE
Make search strings case-insensitive.

### DIFF
--- a/RealmBrowser/Classes/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Classes/RLMRealmBrowserWindowController.m
@@ -431,7 +431,7 @@ NSString * const kRealmKeyOutlineWidthForRealm = @"OutlineWidthForRealm:%@";
                 if (predicate.length != 0) {
                     predicate = [predicate stringByAppendingString:@" OR "];
                 }
-                predicate = [predicate stringByAppendingFormat:@"%@ CONTAINS '%@'", columnName, searchText];
+                predicate = [predicate stringByAppendingFormat:@"%@ CONTAINS[c] '%@'", columnName, searchText];
                 break;
             }
             //case RLMPropertyTypeFloat: // search on float columns disabled until bug is fixed in binding


### PR DESCRIPTION
While testing out the search bar, I discovered that search strings are case-sensitive. This PR makes them case-insensitive in order to make searching a little easier.

Tested on Realm Browser running on both OS X El Capitan and OS X Yosemite.