### PR TITLE
Bump CI disk image to Xcode 7.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: objective-c
-osx_image: xcode7.1
+osx_image: xcode7.1.1
 script: xctool -workspace "RealmBrowser.xcworkspace" -scheme "Realm Browser" test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: objective-c
-osx_image: xcode6.4
+osx_image: xcode7.1
 script: xctool -workspace "RealmBrowser.xcworkspace" -scheme "Realm Browser" test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: objective-c
-osx_image: xcode7.1.1
+osx_image: xcode7.1
 script: xctool -workspace "RealmBrowser.xcworkspace" -scheme "Realm Browser" test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO


### PR DESCRIPTION
Bumping our CI process to use Xcode 7.1 in order to take advantage of the new code features that were introduced to Objective-C in that version.