### PR TITLE
Adding more unit tests to Realm Browser

### DIFF
--- a/RealmBrowser.xcodeproj/xcshareddata/xcschemes/Realm Browser.xcscheme
+++ b/RealmBrowser.xcodeproj/xcshareddata/xcschemes/Realm Browser.xcscheme
@@ -24,8 +24,8 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference

--- a/RealmBrowser/RLMTestDataGenerator.h
+++ b/RealmBrowser/RLMTestDataGenerator.h
@@ -22,6 +22,7 @@
 
 @interface RLMTestDataGenerator : NSObject
 
-+(BOOL)createRealmAtUrl:(NSURL *)url withClassesNamed:(NSArray *)classNames objectCount:(NSUInteger)objectCount;
++ (BOOL)createRealmAtUrl:(NSURL *)url withClassesNamed:(NSArray *)classNames objectCount:(NSUInteger)objectCount;
++ (BOOL)createRealmAtUrl:(NSURL *)url withClassesNamed:(NSArray *)classNames objectCount:(NSUInteger)objectCount encryptionKey:(NSData *)encry;
 
 @end

--- a/RealmBrowser/RLMTestDataGenerator.m
+++ b/RealmBrowser/RLMTestDataGenerator.m
@@ -36,17 +36,26 @@ const NSUInteger kMaxItemsInTestArray = 12;
 // Creates a test realm at [url], filled with [objectCount] random objects of classes in [classNames]
 +(BOOL)createRealmAtUrl:(NSURL *)url withClassesNamed:(NSArray *)classNames objectCount:(NSUInteger)objectCount
 {
+    return [RLMTestDataGenerator createRealmAtUrl:url withClassesNamed:classNames objectCount:objectCount encryptionKey:nil];
+}
+
++ (BOOL)createRealmAtUrl:(NSURL *)url withClassesNamed:(NSArray *)classNames objectCount:(NSUInteger)objectCount encryptionKey:(NSData *)encryptionKey
+{
     NSError *error;
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
     configuration.path = url.path;
     configuration.readOnly = NO;
+    if (encryptionKey) {
+        configuration.encryptionKey = encryptionKey;
+    }
+    
     RLMRealm *realm = [RLMRealm realmWithConfiguration:configuration error:&error];
     
     if (error) {
         [[NSApplication sharedApplication] presentError:error];
         return NO;
     }
-
+    
     RLMTestDataGenerator *generator = [[RLMTestDataGenerator alloc] initWithClassesNamed:classNames];
     [generator populateRealm:realm withObjectCount:objectCount];
     

--- a/RealmBrowserTests/RealmBrowserTests.m
+++ b/RealmBrowserTests/RealmBrowserTests.m
@@ -30,14 +30,23 @@
 
 @implementation RealmBrowserTests
 
-- (void)testGenerateDemoDatabase
+- (NSURL *)urlForGeneratedTestRealmWithClassNames:(NSArray *)classNames count:(NSInteger)count encryptionKey:(NSData *)encryptionKey
 {
     NSString *fileName = [NSString stringWithFormat:@"%@.realm", [[NSUUID UUID] UUIDString]];
     NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
     @autoreleasepool {
-        BOOL success = [RLMTestDataGenerator createRealmAtUrl:fileURL withClassesNamed:@[[RealmObject1 className]] objectCount:10];
+        BOOL success = [RLMTestDataGenerator createRealmAtUrl:fileURL withClassesNamed:classNames objectCount:count encryptionKey:encryptionKey];
         XCTAssertEqual(YES, success);
     }
+    
+    return fileURL;
+}
+
+- (void)testGenerateDemoDatabase
+{
+    NSURL *fileURL = [self urlForGeneratedTestRealmWithClassNames:@[[RealmObject1 className]] count:10 encryptionKey:nil];
+    XCTAssertNotNil(fileURL);
+                      
     NSError *error = nil;
     RLMRealm *realm = [RLMRealm realmWithPath:fileURL.path
                                           key:nil
@@ -52,12 +61,9 @@
 }
 
 - (void)testDoesNotShowObjectsWithNoPersistedProperties {
-    NSString *fileName = [NSString stringWithFormat:@"%@.realm", [[NSUUID UUID] UUIDString]];
-    NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
-    @autoreleasepool {
-        BOOL success = [RLMTestDataGenerator createRealmAtUrl:fileURL withClassesNamed:@[[RealmObjectWithoutStoredProperties className]] objectCount:10];
-        XCTAssertTrue(success);
-    }
+    NSURL *fileURL = [self urlForGeneratedTestRealmWithClassNames:@[[RealmObjectWithoutStoredProperties className]] count:10 encryptionKey:nil];
+    XCTAssertNotNil(fileURL);
+    
     NSError *error = nil;
     RLMRealmNode *realmNode = [[RLMRealmNode alloc] initWithName:@"name" url:fileURL.path];
     XCTAssertTrue([realmNode connect:&error]);
@@ -66,6 +72,31 @@
     for (RLMClassNode *node in realmNode.topLevelClasses) {
         XCTAssertNotEqualObjects(@"RealmObjectWithoutStoredProperties", node.name);
     }
+}
+
+- (void)testEncryptedRealmNode
+{
+    NSMutableData *key = [NSMutableData dataWithLength:64];
+    SecRandomCopyBytes(kSecRandomDefault, key.length, (uint8_t *)key.mutableBytes);
+    
+    NSURL *fileURL = [self urlForGeneratedTestRealmWithClassNames:@[[RealmObject1 className]] count:10 encryptionKey:key];
+    XCTAssertNotNil(fileURL);
+    
+    RLMRealmNode *testNode = [[RLMRealmNode alloc] initWithName:@"Test Realm" url:fileURL.path];
+    XCTAssertNotNil(testNode);
+    
+    //Ensure the Realm file was successfully processed by the node object
+    XCTAssertTrue([testNode.name isEqualToString:@"Test Realm"]);
+    
+    //Check to make sure the encrypted Realm DOES NOT open without the key
+    XCTAssertFalse([testNode connect:nil]);
+    
+    //Pass the encryption key to the node
+    testNode.encryptionKey = key;
+    
+    //Ensure the data in the Realm file is accessible
+    NSLog(@"Classes %@",testNode.topLevelClasses);
+    XCTAssertNotNil(testNode.topLevelClasses);
 }
 
 @end


### PR DESCRIPTION
As part of an ongoing effort to improve Realm Browser, I'm looking at adding more unit tests to the project as I go, in order to further test the business logic behind the app.

This initial refactoring and additional test is to ensure that the logic flow for opening encrypted Realm files in the Browser continues to function properly.