### PR TITLE
Enabled Predominant Axis Scrolling

### DIFF
--- a/RealmBrowser/Base.lproj/RLMDocument.xib
+++ b/RealmBrowser/Base.lproj/RLMDocument.xib
@@ -143,7 +143,7 @@
                                 <rect key="frame" x="237" y="0.0" width="740" height="476"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <subviews>
-                                    <scrollView wantsLayer="YES" focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="20" horizontalPageScroll="10" verticalLineScroll="20" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3b6-BA-X5L" userLabel="MainScroll">
+                                    <scrollView wantsLayer="YES" focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="20" horizontalPageScroll="10" verticalLineScroll="20" verticalPageScroll="10" translatesAutoresizingMaskIntoConstraints="NO" id="3b6-BA-X5L" userLabel="MainScroll">
                                         <rect key="frame" x="0.0" y="0.0" width="740" height="476"/>
                                         <clipView key="contentView" focusRingType="none" id="kRO-aN-FFM">
                                             <rect key="frame" x="0.0" y="0.0" width="740" height="476"/>


### PR DESCRIPTION
This commit enables predominant axis scrolling on the main table view. This makes scrolling quickly much more practical, since you don't always accidentally hit the rebound-effect for horizontal scrolling when scrolling vertically.