### PR TITLE
Added 'Cut', 'Copy', 'Paste', 'Select All' options to 'Edit' menu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 * Improvements to the scrolling performance of the main table view in Realm documents.
 * String-based searches in Realm files made non-case sensitive.
+* Added 'Cut', 'Copy', 'Paste' and 'Select All' menu options, initially to make editing text values easier.
 
 
 0.96.2 Release notes (2015-10-12)

--- a/RealmBrowser/Base.lproj/MainMenu.xib
+++ b/RealmBrowser/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -148,6 +148,27 @@ CA
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="Qmi-Y4-sb2"/>
+                            <menuItem title="Cut" keyEquivalent="x" id="z3i-i2-gcn">
+                                <connections>
+                                    <action selector="cut:" target="-1" id="c9W-9t-Nyw"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Copy" keyEquivalent="c" id="XG2-3G-zAd">
+                                <connections>
+                                    <action selector="copy:" target="-1" id="cPV-fT-Dg0"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Paste" keyEquivalent="v" id="WGQ-ME-KaY">
+                                <connections>
+                                    <action selector="paste:" target="-1" id="8Td-Gt-2qt"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Select All" keyEquivalent="a" id="LGR-0P-v9Y">
+                                <connections>
+                                    <action selector="selectAll:" target="-1" id="pVH-y4-yAI"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="fbn-yl-KvM"/>
                             <menuItem title="Remove Object From Array" tag="110" id="XeB-wT-76a">
                                 <string key="keyEquivalent" base64-UTF8="YES">
 CA


### PR DESCRIPTION
I've added these, initially to make working with the property text fields a bit easier.
Down the line we can start adding custom functionality like duplicating Realm objects, etc.