### PR TITLE
Bug fix for Realm property edits not saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Improvements to the scrolling performance of the main table view in Realm documents.
 * String-based searches in Realm files made non-case sensitive.
 * Added 'Cut', 'Copy', 'Paste' and 'Select All' menu options, initially to make editing text values easier.
+* Fixed an issue where editing properties in Realm objects weren't properly saving to disk.
 
 
 0.96.2 Release notes (2015-10-12)

--- a/RealmBrowser/Classes/RLMInstanceTableViewController.m
+++ b/RealmBrowser/Classes/RLMInstanceTableViewController.m
@@ -347,6 +347,8 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
             RLMBoolTableCellView *boolCellView = [tableView makeViewWithIdentifier:reuseIdentifier owner:self];
             if (!boolCellView) {
                 boolCellView = [RLMBoolTableCellView makeWithIdentifier:reuseIdentifier];
+                boolCellView.checkBox.target = self;
+                boolCellView.checkBox.action = @selector(editedCheckBox:);
             }
             boolCellView.checkBox.state = [(NSNumber *)propertyValue boolValue] ? NSOnState : NSOffState;
             [boolCellView.checkBox setEnabled:!self.realmIsLocked];
@@ -363,6 +365,8 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
             if (!numberCellView) {
                 numberCellView = [RLMNumberTableCellView makeWithIdentifier:reuseIdentifier];
                 numberCellView.textField.delegate = self;
+                numberCellView.textField.target = self;
+                numberCellView.textField.action = @selector(editedTextField:);
             }
 
             numberCellView.textField.stringValue = [realmDescriptions printablePropertyValue:propertyValue ofType:type];
@@ -379,6 +383,8 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
             RLMLinkTableCellView *linkCellView = [tableView makeViewWithIdentifier:reuseIdentifier owner:self];
             if (!linkCellView) {
                 linkCellView = [RLMLinkTableCellView makeWithIdentifier:reuseIdentifier];
+                linkCellView.textField.target = self;
+                linkCellView.textField.action = @selector(editedTextField:);
             }
             NSString *string = [realmDescriptions printablePropertyValue:propertyValue ofType:type];
             NSDictionary *attr = @{NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle)};
@@ -399,6 +405,8 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
             if (!basicCellView) {
                 basicCellView = [RLMBasicTableCellView makeWithIdentifier:reuseIdentifier];
                 basicCellView.textField.delegate = self;
+                basicCellView.textField.target = self;
+                basicCellView.textField.action = @selector(editedTextField:);
             }
             basicCellView.textField.stringValue = [realmDescriptions printablePropertyValue:propertyValue ofType:type];
             basicCellView.textField.editable = !self.realmIsLocked && type != RLMPropertyTypeData;


### PR DESCRIPTION
I noticed an issue today when testing out a Realm file generated by a user's app. At some point, a bug appeared where it became impossible to update the properties inside a Realm file.

This looks like it was due to the fact that the text field controls had to be created in a different way for OS X 10.11, and their `NSControl` actions weren't getting properly set.

This PR fixes that issue.