### PR TITLE
Improve objc model generation

### DIFF
--- a/RealmBrowser/Base.lproj/MainMenu.xib
+++ b/RealmBrowser/Base.lproj/MainMenu.xib
@@ -107,7 +107,7 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Save Model Definitions" id="YSO-b8-a2a">
                                     <items>
-                                        <menuItem title="Save Java definitions..." tag="101" id="kuf-fu-JL0">
+                                        <menuItem title="Save Java definitions..." id="kuf-fu-JL0">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="saveJavaModels:" target="-1" id="6op-mb-kj6"/>
@@ -117,6 +117,12 @@
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="saveObjcModels:" target="-1" id="6Rj-7H-W6J"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save Swift definitions..." id="Nxi-3A-mZH">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="saveSwiftModels:" target="-1" id="7le-yg-BNa"/>
                                             </connections>
                                         </menuItem>
                                     </items>

--- a/RealmBrowser/Classes/RLMModelExporter.h
+++ b/RealmBrowser/Classes/RLMModelExporter.h
@@ -19,8 +19,9 @@
 @import Foundation;
 
 typedef NS_ENUM(NSInteger, RLMModelExporterLanguage) {
+    RLMModelExporterLanguageJava,
     RLMModelExporterLanguageObjectiveC,
-    RLMModelExporterLanguageJava
+    RLMModelExporterLanguageSwift
 };
 
 @interface RLMModelExporter : NSObject

--- a/RealmBrowser/Classes/RLMModelExporter.m
+++ b/RealmBrowser/Classes/RLMModelExporter.m
@@ -250,6 +250,15 @@
             [mContents appendFormat:@"\n+ (NSString *)primaryKey {\n    return @\"%@\";\n}\n", primaryKey];
         }
 
+        NSArray *indexedProperties = [[schema.properties filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"isPrimary == NO && indexed == YES"]] valueForKey:@"name"];
+        if (indexedProperties.count > 0) {
+            [mContents appendString:@"\n+ (NSArray<NSString *> *)indexedProperties {\n    return @[\n"];
+            for (NSString *indexedProperty in indexedProperties) {
+                [mContents appendFormat:@"        @\"%@\",\n", indexedProperty];
+            }
+            [mContents appendString:@"    ];\n}\n"];
+        }
+
         [mContents appendString:@"\n@end\n\n\n"];
     }
 

--- a/RealmBrowser/Classes/RLMModelExporter.m
+++ b/RealmBrowser/Classes/RLMModelExporter.m
@@ -200,26 +200,24 @@
     }
 }
 
-#pragma mark - Private methods - Objective C helpers
+#pragma mark - Private methods - Objective-C helpers
 
-+(NSArray *)objcModelsOfSchemas:(NSArray *)schemas withFileName:(NSString *)fileName
++ (NSArray *)objcModelsOfSchemas:(NSArray *)schemas withFileName:(NSString *)fileName
 {
     // Filename for h-file
     NSString *hFilename = [fileName stringByAppendingPathExtension:@"h"];
     
     // Contents of h-file
-    NSMutableString *hContents= [NSMutableString string];
-    [hContents appendFormat:@"#import <Foundation/Foundation.h>\n#import <Realm/Realm.h>\n\n"];
-    
+    NSMutableString *hContents= [NSMutableString stringWithFormat:@"#import <Foundation/Foundation.h>\n#import <Realm/Realm.h>\n\n"];
     for (RLMObjectSchema *schema in schemas) {
         [hContents appendFormat:@"@class %@;\n", schema.className];
     }
-    [hContents appendString: @"\n"];
+    [hContents appendString:@"\n"];
     
     for (RLMObjectSchema *schema in schemas) {
         [hContents appendFormat:@"RLM_ARRAY_TYPE(%@)\n", schema.className];
     }
-    [hContents appendString: @"\n\n"];
+    [hContents appendString:@"\n\n"];
     
     for (RLMObjectSchema *schema in schemas) {
         [hContents appendFormat:@"@interface %@ : RLMObject\n\n", schema.className];
@@ -228,27 +226,23 @@
         }
         [hContents appendString:@"\n@end\n\n\n"];
     }
-    // An array with filename and contents, i.e. the h-file model
+    // An array with filename and contents for the h-file model
     NSArray *hModel = @[hFilename, hContents];
     
-    // Filename for m-file
-    NSString *mFilename = [fileName stringByAppendingPathExtension:@"m"];
-    
     // Contents of m-file
-    NSMutableString *mContents= [NSMutableString string];
-    [mContents appendFormat:@"#import \"%@\"\n\n", hFilename];
+    NSMutableString *mContents= [NSMutableString stringWithFormat:@"#import \"%@\"\n\n", hFilename];
     for (RLMObjectSchema *schema in schemas) {
         [mContents appendFormat:@"@implementation %@\n\n@end\n\n\n", schema.className];
     }
 
-    // An array with filename and contents, i.e. the m-file model
-    NSArray *mModel = @[mFilename, mContents];
+    // An array with filename and contents for the m-file model
+    NSArray *mModel = @[[fileName stringByAppendingPathExtension:@"m"], mContents];
 
     // An aray with models for both files
     return @[hModel, mModel];
 }
 
-+(NSString *)objcNameForProperty:(RLMProperty *)property
++ (NSString *)objcNameForProperty:(RLMProperty *)property
 {
     switch (property.type) {
         case RLMPropertyTypeBool:

--- a/RealmBrowser/Classes/RLMModelExporter.m
+++ b/RealmBrowser/Classes/RLMModelExporter.m
@@ -278,7 +278,7 @@
 
 + (NSArray *)swiftModelsOfSchemas:(NSArray *)schemas withFileName:(NSString *)fileName
 {
-    // TODO: handle primary key & indexed properties
+    // TODO: handle primary key properties
 
     // Filename
     NSString *swiftFileName = [fileName stringByAppendingPathExtension:@"swift"];
@@ -288,11 +288,23 @@
 
     for (RLMObjectSchema *schema in schemas) {
         [contents appendFormat:@"class %@: Object {\n", schema.className];
+        NSMutableArray<NSString *> *indexedProperties = [NSMutableArray array];
         for (RLMProperty *property in schema.properties) {
             [contents appendFormat:@"  %@\n", [self swiftDefinitionForProperty:property]];
+            if (property.indexed) {
+                [indexedProperties addObject:property.name];
+            }
+        }
+        if (indexedProperties.count > 0) {
+            [contents appendString:@"\n  override static func indexedProperties() -> [String] {\n    return [\n"];
+            for (NSString *propertyName in indexedProperties) {
+                [contents appendFormat:@"      \"%@\",\n", propertyName];
+            }
+            [contents appendString:@"    ]\n  }\n"];
         }
         [contents appendString:@"}\n\n"];
     }
+
     // An array of a single model array with filename and contents
     return @[@[swiftFileName, contents]];
 }

--- a/RealmBrowser/Classes/RLMModelExporter.m
+++ b/RealmBrowser/Classes/RLMModelExporter.m
@@ -317,14 +317,38 @@
 
 + (NSString *)swiftDefinitionForProperty:(RLMProperty *)property
 {
-    // TODO: handle optional properties
-
     NSString *(^namedProperty)(NSString *) = ^NSString *(NSString *formatString) {
         return [NSString stringWithFormat:formatString, property.name];
     };
     NSString *(^objectClassProperty)(NSString *) = ^NSString *(NSString *formatString) {
         return [NSString stringWithFormat:formatString, property.name, property.objectClassName];
     };
+
+    if (property.optional) {
+        switch (property.type) {
+            case RLMPropertyTypeBool:
+                return namedProperty(@"let %@ = RealmOptional<Bool>())");
+            case RLMPropertyTypeInt:
+                return namedProperty(@"let %@ = RealmOptional<Int>())");
+            case RLMPropertyTypeFloat:
+                return namedProperty(@"let %@ = RealmOptional<Float>())");
+            case RLMPropertyTypeDouble:
+                return namedProperty(@"let %@ = RealmOptional<Double>())");
+            case RLMPropertyTypeString:
+                return namedProperty(@"dynamic var %@: String?");
+            case RLMPropertyTypeData:
+                return namedProperty(@"dynamic var %@: NSData?");
+            case RLMPropertyTypeAny:
+                return @"/* Error! 'Any' properties are unsupported in Swift. */";
+            case RLMPropertyTypeDate:
+                return namedProperty(@"dynamic var %@: NSDate?");
+            case RLMPropertyTypeArray:
+                return @"/* Error! 'List' properties should never be optional. Please report this by emailing help@realm.io. */";
+            case RLMPropertyTypeObject:
+                return objectClassProperty(@"dynamic var %@: %@?");
+        }
+    }
+
     switch (property.type) {
         case RLMPropertyTypeBool:
             return namedProperty(@"dynamic var %@ = false");
@@ -345,7 +369,7 @@
         case RLMPropertyTypeArray:
             return objectClassProperty(@"let %@ = List<%@>()");
         case RLMPropertyTypeObject:
-            return objectClassProperty(@"dynamic var %@: %@?");
+            return @"/* Error! 'Object' properties should always be optional. Please report this by emailing help@realm.io. */";
     }
 }
 

--- a/RealmBrowser/Classes/RLMModelExporter.m
+++ b/RealmBrowser/Classes/RLMModelExporter.m
@@ -20,50 +20,59 @@
 @import Realm;
 #import <AppSandboxFileAccess/AppSandboxFileAccess.h>
 
-@interface RLMModelExporter ()
-
-+ (NSString *)stringForLanguage:(RLMModelExporterLanguage)language;
-
-@end
-
 @implementation RLMModelExporter
 
 #pragma mark - Public methods
 
 + (void)saveModelsForSchemas:(NSArray *)objectSchemas inLanguage:(RLMModelExporterLanguage)language
 {
-    NSString *dialogTitle = [NSString stringWithFormat:@"Save %@ model definitions", [RLMModelExporter stringForLanguage:language]];
-    
-    if (language == RLMModelExporterLanguageJava) {
-        NSOpenPanel *fileDialog = [NSOpenPanel openPanel];
-        
-        fileDialog.prompt = @"Select folder";
-        fileDialog.canChooseDirectories = YES;
-        fileDialog.canChooseFiles = NO;
-        fileDialog.canCreateDirectories = YES;
-        fileDialog.title = dialogTitle;
-        [fileDialog beginWithCompletionHandler:^(NSInteger result) {
+    void(^saveMultipleFiles)(NSSavePanel *, void(^)()) = ^void(NSSavePanel *panel, void(^completionBlock)()) {
+        panel.canCreateDirectories = YES;
+        panel.title = [NSString stringWithFormat:@"Save %@ model definitions", [RLMModelExporter stringForLanguage:language]];
+        [panel beginWithCompletionHandler:^(NSInteger result) {
             if (result == NSFileHandlingPanelOKButton) {
-                [fileDialog orderOut:self];
-                NSArray *models = [self javaModelsOfSchemas:objectSchemas];
-                [self saveModels:models toFolder:fileDialog.URL];
+                [panel orderOut:self];
+                completionBlock(panel);
             }
         }];
-    }
-    else if (language == RLMModelExporterLanguageObjectiveC) {
-        NSSavePanel *fileDialog = [NSSavePanel savePanel];
-        fileDialog.prompt = @"Save as filename";
-        fileDialog.nameFieldStringValue = @"RealmModels";
-        fileDialog.canCreateDirectories = YES;
-        fileDialog.title = dialogTitle;
-        [fileDialog beginWithCompletionHandler:^(NSInteger result) {
-            if (result == NSFileHandlingPanelOKButton) {
-                [fileDialog orderOut:self];
-                NSString *fileName = [[fileDialog.URL lastPathComponent] stringByDeletingPathExtension];
-                NSArray *models = [self objcModelsOfSchemas:objectSchemas withFileName:fileName];
-                [self saveModels:models toFolder:[fileDialog.URL URLByDeletingLastPathComponent]];
-            }
-        }];
+    };
+
+    void(^saveSingleFile)(NSArray *(^)(NSString *)) = ^void(NSArray *(^modelsWithFileName)(NSString *fileName)) {
+        NSSavePanel *panel = [NSSavePanel savePanel];
+        panel.prompt = @"Save as filename";
+        panel.nameFieldStringValue = @"RealmModels";
+        saveMultipleFiles(panel, ^{
+            NSString *fileName = [[panel.URL lastPathComponent] stringByDeletingPathExtension];
+            [self saveModels:modelsWithFileName(fileName) toFolder:[panel.URL URLByDeletingLastPathComponent]];
+        });
+    };
+
+    switch (language) {
+        case RLMModelExporterLanguageJava:
+        {
+            NSOpenPanel *panel = [NSOpenPanel openPanel];
+            panel.prompt = @"Select folder";
+            panel.canChooseDirectories = YES;
+            panel.canChooseFiles = NO;
+            saveMultipleFiles(panel, ^{
+                [self saveModels:[self javaModelsOfSchemas:objectSchemas] toFolder:panel.URL];
+            });
+            break;
+        }
+        case RLMModelExporterLanguageObjectiveC:
+        {
+            saveSingleFile(^(NSString *fileName){
+                return [self objcModelsOfSchemas:objectSchemas withFileName:fileName];
+            });
+            break;
+        }
+        case RLMModelExporterLanguageSwift:
+        {
+            saveSingleFile(^(NSString *fileName){
+                return [self swiftModelsOfSchemas:objectSchemas withFileName:fileName];
+            });
+            break;
+        }
     }
 }
 
@@ -92,6 +101,16 @@
         [securityScopedURL stopAccessingSecurityScopedResource];
     }];
 }
+
++ (NSString *)stringForLanguage:(RLMModelExporterLanguage)language
+{
+    switch (language) {
+        case RLMModelExporterLanguageJava: return @"Java";
+        case RLMModelExporterLanguageObjectiveC: return @"Objective-C";
+        case RLMModelExporterLanguageSwift: return @"Swift";
+    }
+}
+
 
 #pragma mark - Private methods - Java helpers
 
@@ -255,14 +274,61 @@
     }
 }
 
-+ (NSString *)stringForLanguage:(RLMModelExporterLanguage)language
+#pragma mark - Private methods - Swift helpers
+
++ (NSArray *)swiftModelsOfSchemas:(NSArray *)schemas withFileName:(NSString *)fileName
 {
-    switch (language) {
-        case RLMModelExporterLanguageJava: return @"Java";
-        default: return @"Objective-C";
+    // TODO: handle primary key & indexed properties
+
+    // Filename
+    NSString *swiftFileName = [fileName stringByAppendingPathExtension:@"swift"];
+
+    // Contents
+    NSMutableString *contents = [NSMutableString stringWithString:@"import RealmSwift\n\n"];
+
+    for (RLMObjectSchema *schema in schemas) {
+        [contents appendFormat:@"class %@: Object {\n", schema.className];
+        for (RLMProperty *property in schema.properties) {
+            [contents appendFormat:@"  %@\n", [self swiftDefinitionForProperty:property]];
+        }
+        [contents appendString:@"}\n\n"];
     }
-    
-    return nil;
+    // An array of a single model array with filename and contents
+    return @[@[swiftFileName, contents]];
+}
+
++ (NSString *)swiftDefinitionForProperty:(RLMProperty *)property
+{
+    // TODO: handle optional properties
+
+    NSString *(^namedProperty)(NSString *) = ^NSString *(NSString *formatString) {
+        return [NSString stringWithFormat:formatString, property.name];
+    };
+    NSString *(^objectClassProperty)(NSString *) = ^NSString *(NSString *formatString) {
+        return [NSString stringWithFormat:formatString, property.name, property.objectClassName];
+    };
+    switch (property.type) {
+        case RLMPropertyTypeBool:
+            return namedProperty(@"dynamic var %@ = false");
+        case RLMPropertyTypeInt:
+            return namedProperty(@"dynamic var %@ = 0");
+        case RLMPropertyTypeFloat:
+            return namedProperty(@"dynamic var %@: Float = 0");
+        case RLMPropertyTypeDouble:
+            return namedProperty(@"dynamic var %@: Double = 0");
+        case RLMPropertyTypeString:
+            return namedProperty(@"dynamic var %@ = \"\"");
+        case RLMPropertyTypeData:
+            return namedProperty(@"dynamic var %@ = NSData()");
+        case RLMPropertyTypeAny:
+            return @"/* Error! 'Any' properties are unsupported in Swift. */";
+        case RLMPropertyTypeDate:
+            return namedProperty(@"dynamic var %@ = NSDate()");
+        case RLMPropertyTypeArray:
+            return objectClassProperty(@"let %@ = List<%@>()");
+        case RLMPropertyTypeObject:
+            return objectClassProperty(@"dynamic var %@: %@?");
+    }
 }
 
 @end

--- a/RealmBrowser/Classes/RLMModelExporter.m
+++ b/RealmBrowser/Classes/RLMModelExporter.m
@@ -262,7 +262,7 @@
         case RLMPropertyTypeDate:
             return @"NSDate *";
         case RLMPropertyTypeArray:
-            return [NSString stringWithFormat:@"RLMArray<%@> *", property.objectClassName];
+            return [NSString stringWithFormat:@"RLMArray<%@ *><%@> *", property.objectClassName, property.objectClassName];
         case RLMPropertyTypeObject:
             return [NSString stringWithFormat:@"%@ *", property.objectClassName];
     }

--- a/RealmBrowser/Classes/RLMModelExporter.m
+++ b/RealmBrowser/Classes/RLMModelExporter.m
@@ -245,6 +245,11 @@
             [mContents appendString:@"    ];\n}\n"];
         }
 
+        NSString *primaryKey = [[[schema.properties filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"isPrimary == YES"]] firstObject] name];
+        if (primaryKey) {
+            [mContents appendFormat:@"\n+ (NSString *)primaryKey {\n    return @\"%@\";\n}\n", primaryKey];
+        }
+
         [mContents appendString:@"\n@end\n\n\n"];
     }
 

--- a/RealmBrowser/Classes/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Classes/RLMRealmBrowserWindowController.m
@@ -127,16 +127,25 @@ NSString * const kRealmKeyOutlineWidthForRealm = @"OutlineWidthForRealm:%@";
 
 #pragma mark - Public methods - Menu items
 
-- (IBAction)saveJavaModels:(id)sender
+- (void)saveModelsForLanguage:(RLMModelExporterLanguage)language
 {
     NSArray *objectSchemas = self.modelDocument.presentedRealm.realm.schema.objectSchema;
-    [RLMModelExporter saveModelsForSchemas:objectSchemas inLanguage:RLMModelExporterLanguageJava];
+    [RLMModelExporter saveModelsForSchemas:objectSchemas inLanguage:language];
+}
+
+- (IBAction)saveJavaModels:(id)sender
+{
+    [self saveModelsForLanguage:RLMModelExporterLanguageJava];
 }
 
 - (IBAction)saveObjcModels:(id)sender
 {
-    NSArray *objectSchemas = self.modelDocument.presentedRealm.realm.schema.objectSchema;
-    [RLMModelExporter saveModelsForSchemas:objectSchemas inLanguage:RLMModelExporterLanguageObjectiveC];
+    [self saveModelsForLanguage:RLMModelExporterLanguageObjectiveC];
+}
+
+- (IBAction)saveSwiftModels:(id)sender
+{
+    [self saveModelsForLanguage:RLMModelExporterLanguageSwift];
 }
 
 - (IBAction)saveCopy:(id)sender


### PR DESCRIPTION
* Use Objective-C generics
* Handle optional properties
* Handle primary keys
* Handle indexed properties

Depends on #120. See https://github.com/realm/realm-browser-osx/compare/jp-generate-swift-models...jp-improve-objc-model-generation for just the changes in this PR.

/cc @TimOliver 