### PR TITLE
Bug fix for rendering issue caused by same-name properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Added the ability to generate Swift model classes from a Realm file.
 * Improvements to the Objective-C model generation, including generics and Realm's latest features.
 * Improvements to the Java model generation, handling primary, indexed and required fields.
+* Fixed a rendering issue involving properties in different objects that had the same name.
 
 0.97.0 Release notes (2016-01-14)
 =============================================================

--- a/RealmBrowser/Controllers/RLMInstanceTableViewController.m
+++ b/RealmBrowser/Controllers/RLMInstanceTableViewController.m
@@ -331,7 +331,7 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     RLMObject *selectedInstance = [self.displayedType instanceAtIndex:rowIndex];
     id propertyValue = selectedInstance[classProperty.name];
     RLMPropertyType type = classProperty.type;
-    NSString *reuseIdentifier = [@"property." stringByAppendingString:classProperty.name];
+    NSString *reuseIdentifier = [NSString stringWithFormat:@"property.%@.%@", self.displayedType.schema.className, classProperty.name];
     
     NSTableCellView *cellView;
     switch (type) {


### PR DESCRIPTION
A user reported a bug where content in cells wasn't rendering correctly in one of the tables of their Realm file.

I managed to track down the cause being that both the initial table, and the erroneous table both had a property named `identifier`, but were of type `NSString` in the first table, and `NSInteger` in the second. Due to the way the Browser recycled table cells based off identifier strings generated from the schema names, this was causing the incorrect cells to be recycled for the `NSInteger` property column.

This bug fix segregates cell creation on a per-table basis, eliminating this problem.