### PR TITLE
Update to Realm 0.98.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
-* Updated to Realm 0.98.2
+
+0.98.6 Release notes (2016-03-29)
+=============================================================
+* Updated to Realm 0.98.6
+
+0.98.5 Release notes (2016-03-15)
+=============================================================
+* Updated to Realm 0.98.5
 * Added the ability to generate Swift model classes from a Realm file.
 * Improvements to the Objective-C model generation, including generics and Realm's latest features.
 * Improvements to the Java model generation, handling primary, indexed and required fields.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,9 +2,9 @@ PODS:
   - AppSandboxFileAccess (1.0.14)
   - CSwiftV (0.0.3)
   - PathKit (0.6.0)
-  - Realm (0.98.5):
-    - Realm/Headers (= 0.98.5)
-  - Realm/Headers (0.98.5)
+  - Realm (0.98.6):
+    - Realm/Headers (= 0.98.6)
+  - Realm/Headers (0.98.6)
   - RealmConverter (0.1):
     - CSwiftV
     - PathKit
@@ -17,22 +17,13 @@ PODS:
 DEPENDENCIES:
   - AppSandboxFileAccess
   - Realm
-  - RealmConverter (from `https://github.com/realm/realm-cocoa-converter.git`)
-
-EXTERNAL SOURCES:
-  RealmConverter:
-    :git: https://github.com/realm/realm-cocoa-converter.git
-
-CHECKOUT OPTIONS:
-  RealmConverter:
-    :commit: 5ac4edac545a8809bb2df69a50bfba1627f22e79
-    :git: https://github.com/realm/realm-cocoa-converter.git
+  - RealmConverter
 
 SPEC CHECKSUMS:
   AppSandboxFileAccess: f3e10b0ba10bbaa6dc6996639ff47836050329c5
   CSwiftV: 93e3d4e1501f2a9b1eac3ae51d53a5edf41beb5b
   PathKit: b224b6d2c4e75b87f08f45e1c0c610a3195c94e5
-  Realm: db08379969e45cea2edd1c3c0a090fe9e22d2d2f
+  Realm: 44803f35418c5d89b27825a564247fcd190de37e
   RealmConverter: 1f687f9df48efe5828bdcc1d0ab5c459768c2ee2
   SSZipArchive: de3d215ab73f87db627f81f2ce24f1731e3886c3
   TGSpreadsheetWriter: 09bbb2c18a111a11c94ff9c1af2320e2530c958e

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -2,9 +2,9 @@ PODS:
   - AppSandboxFileAccess (1.0.14)
   - CSwiftV (0.0.3)
   - PathKit (0.6.0)
-  - Realm (0.98.5):
-    - Realm/Headers (= 0.98.5)
-  - Realm/Headers (0.98.5)
+  - Realm (0.98.6):
+    - Realm/Headers (= 0.98.6)
+  - Realm/Headers (0.98.6)
   - RealmConverter (0.1):
     - CSwiftV
     - PathKit
@@ -17,22 +17,13 @@ PODS:
 DEPENDENCIES:
   - AppSandboxFileAccess
   - Realm
-  - RealmConverter (from `https://github.com/realm/realm-cocoa-converter.git`)
-
-EXTERNAL SOURCES:
-  RealmConverter:
-    :git: https://github.com/realm/realm-cocoa-converter.git
-
-CHECKOUT OPTIONS:
-  RealmConverter:
-    :commit: 5ac4edac545a8809bb2df69a50bfba1627f22e79
-    :git: https://github.com/realm/realm-cocoa-converter.git
+  - RealmConverter
 
 SPEC CHECKSUMS:
   AppSandboxFileAccess: f3e10b0ba10bbaa6dc6996639ff47836050329c5
   CSwiftV: 93e3d4e1501f2a9b1eac3ae51d53a5edf41beb5b
   PathKit: b224b6d2c4e75b87f08f45e1c0c610a3195c94e5
-  Realm: db08379969e45cea2edd1c3c0a090fe9e22d2d2f
+  Realm: 44803f35418c5d89b27825a564247fcd190de37e
   RealmConverter: 1f687f9df48efe5828bdcc1d0ab5c459768c2ee2
   SSZipArchive: de3d215ab73f87db627f81f2ce24f1731e3886c3
   TGSpreadsheetWriter: 09bbb2c18a111a11c94ff9c1af2320e2530c958e

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,2022 +1,7126 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		000ECEEFBA9B290EBF4D0B5E3789D37C /* aestab.c in Sources */ = {isa = PBXBuildFile; fileRef = E22CE0498E06FD67D741E59D96E720A5 /* aestab.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		0516C976D88B0DEE23481F946CB6C6CE /* transact_log_handler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F52EC04D9DC0AE2842735C7D17BD3787 /* transact_log_handler.cpp */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		062DCE379C878985044360451F35E744 /* pwd2key.c in Sources */ = {isa = PBXBuildFile; fileRef = 06C5909E9BA9F11BC60281FCB528DDC7 /* pwd2key.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		07F70FB9AA910A28D5288F38B34AB36D /* Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1ECB794421C4581658AE60E13BEA337 /* Encoding.swift */; };
-		09D4AA5011C7C94D70BCEEDD2DD935DF /* aes.h in Headers */ = {isa = PBXBuildFile; fileRef = 372D1E999518B8EE3D71FC3340D164A5 /* aes.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		0A47C7CA19CBD3E41CCD34CA089058D4 /* AppSandboxFileAccessOpenSavePanelDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A585A14DEE51BD017795B9A5BFF371 /* AppSandboxFileAccessOpenSavePanelDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1055889BAFAFD6054D7B61D9614CFC8E /* RLMPlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = AB0FBCDE4D353AAC203D8510CD88849D /* RLMPlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		10E29DDE9550025C74EA23C7E4CEF0F7 /* crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = B4231AE1512289C8EA19666DD531F5B4 /* crypt.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		118555F3BDF23E1DE2A8A5F6E4317672 /* shared_realm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95420313339AF991DDC48B242C068AB0 /* shared_realm.cpp */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		139D64691FB0421C1AAF22EAD4D010B9 /* RLMProperty.mm in Sources */ = {isa = PBXBuildFile; fileRef = A19421B9966A85C3EAC8DDC4FBCFCAF9 /* RLMProperty.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		14E8241278CA6C4ED286431E1BDCF9F2 /* RLMObject_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F10FF47841D4AAA329F613B6EC48340 /* RLMObject_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		158F8B831CCE64F91B39867CEEF47BF6 /* RealmConverter-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EFED74A2EBBF8322E32677C9304BE56 /* RealmConverter-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		15A2F91F6D730434DFA8020C30BFE6AF /* CSwiftV-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DBE7F0C00830063060771EF7F00929D9 /* CSwiftV-dummy.m */; };
-		17C390119E3AD0EBBB7477FD919A80AA /* hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = B8C4745957C099E9682B5181B1928187 /* hmac.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		18A26B02BF9CEAF6AAA809AB342B5307 /* AppSandboxFileAccessPersist.h in Headers */ = {isa = PBXBuildFile; fileRef = A042AC754D95496EB6398473225A7078 /* AppSandboxFileAccessPersist.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1C2ABCB19989B2949F3E5B578A16C3B5 /* fileenc.c in Sources */ = {isa = PBXBuildFile; fileRef = FD49C997C594336277C7D44719D71E59 /* fileenc.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		1E8B84BB47AB9083CE26251F95C8A7EE /* RealmConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = C9200253A8AE36C3AB6DEFE3AC62C075 /* RealmConverter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		21D5C26A2BD3B0DC4FA654BF4180E86D /* ImportSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127C0D709EA76419CDD3F71CB1C11EAD /* ImportSchema.swift */; };
-		21E000387A093C76D06321BF3BC9E425 /* PathKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 250D3DADF320E007F9BF93AB25F8A037 /* PathKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		225120EAF6EB8A24B02186AD56F19CF4 /* RLMResults.mm in Sources */ = {isa = PBXBuildFile; fileRef = DFA0C81489C637F0DA69EB1F54B6AEE5 /* RLMResults.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		2282975F057A6767A8F330DC75192839 /* brg_types.h in Headers */ = {isa = PBXBuildFile; fileRef = EE34A6272512B232D721068FFE5A4D78 /* brg_types.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		250D71DE54AEC07D94A28427C528A526 /* RLMSwiftSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 4918C17F01E89C4D4A1EF222716F5C4C /* RLMSwiftSupport.m */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		25601A4F933B0288BA887045FAD4DB8A /* RLMConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 43103CF0EDC745ED1FABF936B4334F8D /* RLMConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		26DDB79D8ABBFEB95FEC26066757C496 /* DataImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C39ECE6DDDADF5E1A4F45352B339E4 /* DataImporter.swift */; };
-		272CE2753DF442F09C9C7735893CD9A2 /* AppSandboxFileAccessPersist.m in Sources */ = {isa = PBXBuildFile; fileRef = A1DA738A84039E33733961E6B3E317D9 /* AppSandboxFileAccessPersist.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		2BC251710F9BCC30D0A27631D64CD789 /* Realm-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F49D90E43BEB2AA8A737BADDCBAA3087 /* Realm-dummy.m */; };
-		2D57B36C8CC1632E4C1667D8C845630B /* aescrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 31081229799E9933D1976C60F2B8AE47 /* aescrypt.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		2E428116A40B080D11E84AB8F6BCD7A5 /* TGSpreadsheetWriter-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C39AF29E5B53613D57105A4F510B0CD /* TGSpreadsheetWriter-dummy.m */; };
-		2EBD35649FB2E40FF0EEB5E150F57A0B /* sha1.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C6E2396FEF3F056166688C4BFD133CE /* sha1.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		30B394005B43898E7D40C54F8CD2D80E /* Pods-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 894E5DA93A9F359521A89826BE6DA777 /* Pods-dummy.m */; };
-		314AF406EAE652723D243081FFC5B55D /* zip.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F7A768A0AD58A0C9F06AA6725EF8BDA /* zip.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		357D4F9B5F22AEB1F51AC790B0DE05C9 /* RLMArray.h in Headers */ = {isa = PBXBuildFile; fileRef = A68A5681C548CA29D8B6854F430B46FA /* RLMArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3ABC47F83F9119370B9EFB7F039FB5A1 /* schema.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AE19F1FFD4B623527C27BF05D2BF31D /* schema.cpp */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		3B0EE4ACCD03BBF2440A3693C074066C /* RLMDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = A0496BBB3CF3A07D65946972DDCB906C /* RLMDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3B6D4BAA76130B9A44305448F6A766BC /* hmac.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E68AE67BA0144854548E9637BE351FF /* hmac.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		3C13BE699CCAB51C4D31542233FC5755 /* index_set.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03424E15C2D5A576CD2A2ED39E6C6E9B /* index_set.cpp */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		3E7DDF75C64B7C507AF21ED0B97FA016 /* RLMObjectSchema_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C4B83AB3AD2940C100050FC255571F5B /* RLMObjectSchema_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		3FC698B87150A428B273817AA134E9A5 /* RLMObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F457A03F9AAC050288B25C55486010D /* RLMObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		446866786867E9531A8AF2C25EED58D7 /* RLMSchema_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DCE2B1A050EB5CEEA7ADDCD3C05F54E0 /* RLMSchema_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		44C8CAAF531F32F5FC732AF78C17E28F /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = C7DE9DCC709D99E2D78137CE68DA06EB /* sha1.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		4ADAC9B7313F63B34197CA1F4A9E9C72 /* RLMRealm_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = EDAA7BD525EAC1621E00BCBC3E8C1EC5 /* RLMRealm_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4CBA3872A464CD39846C56038EBD8FCF /* AppSandboxFileAccess.m in Sources */ = {isa = PBXBuildFile; fileRef = A086A964EFA9C3A7879C3129B759FFCE /* AppSandboxFileAccess.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		4E13713123BFFC907929C327E0D257D6 /* TGSpreadsheetWriter-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F35DD12E0FAF85C747FB80152808849 /* TGSpreadsheetWriter-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4FC442CF7DD73E52ECFD60891097F2AE /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2E224763DAA078EE22DC2EF01A9B1F6 /* Cocoa.framework */; };
-		50743BC1BE695769AC87A79B2D7F0D82 /* RLMRealmConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 24BB64FDE8E4F4C58C66185E955469AF /* RLMRealmConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		511F4A56904027806B5D5027A81ABB02 /* fileenc.h in Headers */ = {isa = PBXBuildFile; fileRef = 05C969245C1B62E7985DEA4377653C72 /* fileenc.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		514DAA1755FE0C7F1F98E79CBA8F33D4 /* external_commit_helper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 355392CC6F82DB3D00CEF56FC4B53633 /* external_commit_helper.cpp */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		52034685912B207EF4207E28EDEC4318 /* RealmConverter-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FEC311E12DB84B8600A60E9FBA3799E0 /* RealmConverter-dummy.m */; };
-		56B31612F88D2271F385321D48D85612 /* object_store.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8803880F9B2DEDE45EBF1B8ECE83A699 /* object_store.cpp */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		57CDBDC59BAED9EACDBECDCA5129FD7B /* RLMMigration.h in Headers */ = {isa = PBXBuildFile; fileRef = 1020DC3FBB8E70DE1DAE17C97E85333E /* RLMMigration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5B0A178E457A92024A18B74C29DD577C /* RLMObjectBase.h in Headers */ = {isa = PBXBuildFile; fileRef = B8AE37511CF793AD65D0B6411DE3C4D1 /* RLMObjectBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5BA359F4E8AD40493C48EA6A19F60CAF /* RLMObjectSchema.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3824AA76DE171EAD9ACF0C6BA55B45D3 /* RLMObjectSchema.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		5E6507B634AA2F13EE0EB877310A0C6B /* RLMArrayLinkView.mm in Sources */ = {isa = PBXBuildFile; fileRef = A02FB283C242F581628F1E1860C29BA3 /* RLMArrayLinkView.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		5E98C43341C9E0E0241302AFCC22404F /* RLMAnalytics.mm in Sources */ = {isa = PBXBuildFile; fileRef = 111C0E4A52077D19B9B5AE075F686880 /* RLMAnalytics.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		5F702A59D013D9F682E348CA76AEE172 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2E224763DAA078EE22DC2EF01A9B1F6 /* Cocoa.framework */; };
-		60FFAFC5F767C92C68EB6A8F1D7F3EE3 /* DataExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0ED6A24D351EA7318641F59FA8CC831 /* DataExporter.swift */; };
-		6248F8F3D5A83C7F0EE043E23A953A5E /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 35D92536BDC8AB8DEBA3A5613FC1BFFE /* ioapi.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6315AC8453D02A3FD59F9F71F364EA46 /* ioapi.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D5BD286B05E51E6578C46A92D09BFC3 /* ioapi.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6540D3CEB07A63EE8CB4DE046333219F /* entropy.c in Sources */ = {isa = PBXBuildFile; fileRef = 8B7EFFBC7FFCD4E65241A123E257CF7F /* entropy.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6A4B50C549836B1559B971C3E826819D /* AppSandboxFileAccessOpenSavePanelDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A878C683463E5D95C28E7DF9A2068391 /* AppSandboxFileAccessOpenSavePanelDelegate.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		7090784F4AC1E6E82F80899C759347E2 /* ImportObjectSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79764CC7086366871B7D1D089EE9CEDE /* ImportObjectSchema.swift */; };
-		71758734DCAB13CB42491204952F215A /* async_query.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6B2A3090815002E3CB22D9C0833BB20D /* async_query.cpp */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		7255CE045B5B76EA81FCBF9EE90E66CC /* CSVDataExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27036DAD4BB60AF60BE6BC2BE2791BD7 /* CSVDataExporter.swift */; };
-		775B9FF071C51C2CB231169D9D0DDD8C /* RLMPredicateUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = E84A16B2DD844599EC3037DA81D2038D /* RLMPredicateUtil.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		78886685330CBFF0AFA0004658A5B4C5 /* RLMProperty_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 04B964E9C58BE2B1D8E41942B9D7242E /* RLMProperty_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		790DA773FCBB81AD7A9ADF0B7F86C66A /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C604182F0C5BD5AB1B9EF2BD4B7D22 /* PathKit.swift */; };
-		794ADD6313E9489BEC5E61A3457BC749 /* RLMAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 594E74B6BCE69D8DD34926C7D82C9178 /* RLMAccessor.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7973B04F5D5599AEE7AC1C4E569DBC3D /* ZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 05A29D9811FE50FC553EE8380C12A459 /* ZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		839C6F803412E9E34416A049CB85BD85 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C757FF507346A6EB9D2540C8E620D79 /* Realm.framework */; };
-		855857FDF0A68C81EE20F8AFF89A998D /* RLMRealm.h in Headers */ = {isa = PBXBuildFile; fileRef = 1613577FE131ADE567FBD6DF6F3FDA70 /* RLMRealm.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		861D5388547D81FC79FE89944449FBA2 /* RLMAccessor.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0C32BDA03399CEE008733EC4E942F5AB /* RLMAccessor.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		86A6FDB24833F6E99807B9EDD3CB9ED4 /* cached_realm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 54C8EB611A0A77E462591BD7970E7968 /* cached_realm.cpp */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		873894328ED6A3681E0BBE84F33F9156 /* ImportSchemaGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE2B9AFFC43023F6FF64F38F3DBBECE /* ImportSchemaGenerator.swift */; };
-		89D13F76001C05818D50C48B10052874 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2E224763DAA078EE22DC2EF01A9B1F6 /* Cocoa.framework */; };
-		8A66293323CD45D2852C2D42D612D53D /* RLMMigration.mm in Sources */ = {isa = PBXBuildFile; fileRef = D24235CDF995FC31A2897A5A7283FC5E /* RLMMigration.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		8AA5E9FFE41C8340BA3B262A2A0EA12E /* RLMOptionalBase.mm in Sources */ = {isa = PBXBuildFile; fileRef = FC70D2C69CFEAFBE595CF4B7A74BF947 /* RLMOptionalBase.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		8D9A038653F6DD0202AC51BED1C1A389 /* object_schema.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9A5A17348B4D0E60ABAA4D040EA8DFED /* object_schema.cpp */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		904335DE07D1D67885592BA72317EEAC /* TGSpreadsheetWriter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F42F2F73B04A3EC00CF51F753925309C /* TGSpreadsheetWriter.framework */; };
-		90A17AC7A1011EB1D7EF60F985DBA0EF /* realm_coordinator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ED8762338AC853B059F0078B7BF54C74 /* realm_coordinator.cpp */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		92C77F228BD83616B71F63BD4DB0E24A /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2E224763DAA078EE22DC2EF01A9B1F6 /* Cocoa.framework */; };
-		9448EEA86EEF2C88F0678F62B00BB0D1 /* AppSandboxFileAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = D5165BCE41EC813689C4C6F4F29CC3C6 /* AppSandboxFileAccess.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		95E6F9493F288E78458063FDA63ED930 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = BD25BCAEC40792D702B165DC4E0E4068 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		970D6045BECE13C47427CE89CDF56132 /* entropy.h in Headers */ = {isa = PBXBuildFile; fileRef = 89F0037B1208F4778B38B0CFF68348A7 /* entropy.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		999AC8D622FC0F2C1073826143685189 /* XLSXDataImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD5C8EFBD82FCA7F4C711DDCE626676 /* XLSXDataImporter.swift */; };
-		9BD3D7793D7ED32F397541EB7A03ADAF /* RLMRealm_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC0335B8B9B9D0BA1CC6AF6495929D9 /* RLMRealm_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		9CD712A5BA98A0C0C46E0A468B7A7C48 /* RLMObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = DAB7D91BBCF663D88A2F0482906EB695 /* RLMObject.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		9E3042C037127666D3EC4870E35931F1 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 55EB30039FA973FA56CBC419DE912DC7 /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9F183C647578D111DF61F06BBFF6143E /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = 70153F79B788A90BC4A9E3679583D60D /* unzip.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		9FF09B4D2038571D92013130C5067096 /* RLMListBase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 14EFD886E4361BC20FB65E7089303D8B /* RLMListBase.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		A0D4017D654BA0F228DA44BCE40EFA69 /* RLMObjectStore.mm in Sources */ = {isa = PBXBuildFile; fileRef = A3F3D3E4246FB153A3C238A0890D8C7A /* RLMObjectStore.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		A2FD0A3B9B6479962E5C7B9BCD2B2EEA /* unzip.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E4D5458A3957A50C451BDD460A8146 /* unzip.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		A3AB553C1F23F2F94FBCC183AF919508 /* RLMRealmConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1E0615CF56088C501D87706816F66F05 /* RLMRealmConfiguration.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		A4BFF8BBF8068EA5B85C3BEF335FDE11 /* RLMQueryUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = DB255E01E754531C0F73C07C6ECAACC1 /* RLMQueryUtil.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		A72F6E679B47FA5BD09F2A9515288036 /* Realm.h in Headers */ = {isa = PBXBuildFile; fileRef = 59F03CA5F870A59A7DC4FE571FF85A80 /* Realm.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A877F61198EF32BBAF3625076D9467D2 /* CSwiftV-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E95F14A837F5530701D153685999E18 /* CSwiftV-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA867865E78E83FEA0E3998A8CE7EAAC /* SSZipArchive-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 44A1469F401CF6008E8A2F3F60BC10BD /* SSZipArchive-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB463BFDEF905F5059456498455BECEA /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2E224763DAA078EE22DC2EF01A9B1F6 /* Cocoa.framework */; };
-		ACC6BDC6C06EB57F55D1AFC39749FD6D /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CF4D42A8F0D4F169E76D4E90E5C74C0 /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ACD8B8D4E93FBEB126BE3970FB377C17 /* RLMObjectSchema.h in Headers */ = {isa = PBXBuildFile; fileRef = A30A2A989CC72FB4D46E1C18FEAC1E4B /* RLMObjectSchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AED3600F6B88D062A901C0D2EBCC7752 /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = AFFAACC04CCAFAC7EF65AE188FFE14F6 /* SSZipArchive.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		AF05BE9D1B49B2BFE46731DBC4D3B017 /* CSwiftV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 745CFE9844D5ADA3FA496AF4EA9A2391 /* CSwiftV.framework */; };
-		AF90AFF3C49DC4F5BFDDE81C8CF33C94 /* RLMConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = BF080C07656878AAB4897C2BBFA46B13 /* RLMConstants.m */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		AFF0DE37AF5F2ACAF91FB1D3D2DE329B /* RLMListBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 3803D882518A91345A998713852DBFE9 /* RLMListBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B1C6632902573DE8DC763DF17736FC45 /* RLMArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07894E49BED389CD196F901827EC6A19 /* RLMArray.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		B28738B7DBEFB9D43FC99EF9818A6916 /* TGSpreadsheetWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = F12D867DADEF9CF1B5E8F866B13DFF9B /* TGSpreadsheetWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B453E7A00408F4A77F033EDBD665E0ED /* RLMRealmConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 999C6BE75E407953D138E873E91D3E21 /* RLMRealmConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B46FF231A9ED26AC96F3200492562CEC /* RLMCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = A970B9FC0E0B15EB134A53D39BA938E3 /* RLMCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B5CC27E512BE35B3C19918582A3F1FD6 /* prng.h in Headers */ = {isa = PBXBuildFile; fileRef = 4135B47426BBD4B027107FDD7DEFB3FB /* prng.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		B80B0212901845EC122FCFCAF660DB1D /* AppSandboxFileAccess-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B1FCEDB643FAF9E812BD22FC813BA25A /* AppSandboxFileAccess-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B934A7BE0B67E9AB2143755F3388AC62 /* mztools.h in Headers */ = {isa = PBXBuildFile; fileRef = DE7AD83A17E01FB317130543AB9C44A6 /* mztools.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BA055B534BD93E1154E785ED24765C0D /* CSwiftV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72176F811D85F6AE2E7BF90CBD601644 /* CSwiftV.swift */; };
-		BA7B2DACB5CF0834E1B165A0BED8854E /* zip.c in Sources */ = {isa = PBXBuildFile; fileRef = FD499AC05B2273EEBB6CCEACDFB0D19A /* zip.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		C0346FDF36155B025E7FE4B13227A243 /* mztools.c in Sources */ = {isa = PBXBuildFile; fileRef = 3198887C97EACA777370AE6F188AF829 /* mztools.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		C238473D12590CFD4363445513344DFB /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2E224763DAA078EE22DC2EF01A9B1F6 /* Cocoa.framework */; };
-		C5BEA4C7CAC26163DFE867E0510006E7 /* RLMOptionalBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 9ABC69341A34F40BBD661AE423D06E3E /* RLMOptionalBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C7D6BADCE9C5D01C8F55865D07158BD0 /* RLMSchema.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7210605A669DE89C7D8A5F4395EEAD7E /* RLMSchema.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		C95637F789EB1F555F898F9A90279731 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2E224763DAA078EE22DC2EF01A9B1F6 /* Cocoa.framework */; };
-		CBAD2B66321765D0F602D8546BA70B86 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E85BD6029B5A4E38247B8133FA951E9 /* PathKit.framework */; };
-		CC0E23DC1A89303BD763AF75D5CFEC85 /* CSVDataImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21FF966A642F7DF524A2FFD92271B27 /* CSVDataImporter.swift */; };
-		CF2E9B7C1D862BB5667287B02F918198 /* prng.c in Sources */ = {isa = PBXBuildFile; fileRef = 86961DC4D50C3885E3F4A6B9039F2554 /* prng.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		CF4AD6AAD96373B95789F35D8E9D3785 /* aes_via_ace.h in Headers */ = {isa = PBXBuildFile; fileRef = 716C4A29792DD68A1977222812EEF84D /* aes_via_ace.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		CF71512BD773F9F94F95DF5A26013BC2 /* RLMUpdateChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5A24BC47325BB22483160927840DA2CC /* RLMUpdateChecker.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		D0B5097631EF99C0653439E1100F94E1 /* brg_endian.h in Headers */ = {isa = PBXBuildFile; fileRef = AA353BA701BC4981916B046E80579AFF /* brg_endian.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D2FB1939848665F80BA9A114A3F79A8D /* aesopt.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F441B555B2179F592E1CBA38663A808 /* aesopt.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D478998D346D9B7B148CCA1D90F73C62 /* Pods-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BCC458FDD5F692BBB2BFC64BB5701FC /* Pods-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D5284C3580D66E6D035869B2A11DFB8B /* RLMUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1BA86B34A7ADF7C1260A7466874DD7D5 /* RLMUtil.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		D79BCA99C1FC7A2B3224FBC676957F7A /* RLMObservation.mm in Sources */ = {isa = PBXBuildFile; fileRef = C1B856FA1794963765B6B11447040661 /* RLMObservation.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		D822F3F5388DA53393ED93B9350C5702 /* TGSpreadsheetWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3530DBF75398985B0150C5517334CD82 /* TGSpreadsheetWriter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		D85E6244F76B7F8B12D4D391494C549E /* RLMResults.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B1F27CAFD4C276D9D74B2A933F3CB45 /* RLMResults.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DC2E40164119E256D7CD886FE068C029 /* RLMResults_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C5504A46EA0B3A6D2FE2C3911CDFACA4 /* RLMResults_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		DCE6244F4798467314F0547A1598949D /* PathKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E3CD6EF222114C791F5F8A6F461A0C2D /* PathKit-dummy.m */; };
-		DE210B0FAF0C41A54011E0736706C9AD /* aeskey.c in Sources */ = {isa = PBXBuildFile; fileRef = A8429AF4EF3E7FBCBE758A1200B23AE7 /* aeskey.c */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		E1AC9B1FE18A1562F9378EC7DFAD8648 /* SSZipArchive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DDDA9921A7144720EB431B6CAF58571 /* SSZipArchive.framework */; };
-		E29C0C24B7ADE76C71CCCEAC37FB4D19 /* RLMMigration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 21B59C1A4A3C949D88977978CDDCD0DF /* RLMMigration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E2CC6849183CBD5E289DEA7828844947 /* ZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B67266F7743232CEEA01857DEFCDC88 /* ZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E3542F21C12A8F20472B801BE260DDEF /* SSZipArchive-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B53D6206CA911D031F8053FC6636C7B1 /* SSZipArchive-dummy.m */; };
-		E594D6C2C03BE35386B70A6233F7CE33 /* results.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B52762951A1DBC3E77A33ABD829FEE0D /* results.cpp */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		E68BB55BC804EA907D8B5534ECCB03EB /* Common.h in Headers */ = {isa = PBXBuildFile; fileRef = 54C6E0D9A39100A1B977F6AA98B6B498 /* Common.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E704B906C21A38A983C00338833CFC7D /* Common.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BD2BCEDFB78A820E986BC125AB99112 /* Common.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EA9AFA5D4BDF826B46132B8949545DD0 /* RLMProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CAF6C55A82A67E4B3D1003CFB3369A9 /* RLMProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EB301B35774250D9DAF20A1BAFAC6914 /* aestab.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F99C81EE3FD403B46B3F5D39C6B71D0 /* aestab.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		EB9A01C742FE18F233430751C19EAE7B /* String+CamelCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBB05F4BA4BADCFFC489810FA229A121 /* String+CamelCase.swift */; };
-		EC4E64AD48AAF9E2943ACB390398369A /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2E224763DAA078EE22DC2EF01A9B1F6 /* Cocoa.framework */; };
-		EE7A46055D614EB4E266A6A8678BA94B /* AppSandboxFileAccess-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 17650893B51708A441A7FF79DEF2DAD0 /* AppSandboxFileAccess-dummy.m */; };
-		F0C0D57BB3AD8DD7721499CDA0B333A2 /* RLMRealmUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4F76EFE18C9CC8BC88AE6DA1C782FE1C /* RLMRealmUtil.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		F26D7088043EDB28FC0D9C7ACEB6AC57 /* RLMArray_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C3C4E3105B0FA8266054F37B2AE56540 /* RLMArray_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F331322EACCE12E8E004AAA7CB2A8AC4 /* RLMObjectBase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37EDB653332F73BE50868CAE1799508D /* RLMObjectBase.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-		F3FB5656F92619F47C6C5F3967907E13 /* RLMSchema.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B77BF0083B2A3FE0247DC63E8C16CA0 /* RLMSchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F5A9E0302889F8E71A9B4C9F42484862 /* pwd2key.h in Headers */ = {isa = PBXBuildFile; fileRef = AAE0D156249D94D4B7EA6573E78BECF5 /* pwd2key.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F7435CF4F860EB2FC48BF128CB315A71 /* RLMObjectStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 68FF1B6FC0C6DE4F36B50D5E4E87AFF8 /* RLMObjectStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F7616315433905E44350B61CF1F3AF2B /* RLMRealm.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0BB450E5051F002DCD6DF65F4C4F147F /* RLMRealm.mm */; settings = {COMPILER_FLAGS = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"0.98.5\"' -D__ASSERTMACROS__"; }; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		0A832F515C62BDDA906C29AA023E898A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C9289771C9E400167D4D291E44982A06;
-			remoteInfo = CSwiftV;
-		};
-		1A73584D0AF5ED5D935679953F3A399D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A1E90C16CA7394ABAE6952B4887A7B81;
-			remoteInfo = RealmConverter;
-		};
-		243F8EFF55CCACD27364AAAAE26DB1B5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D0CD4B404F898BAC414372B461A667BF;
-			remoteInfo = Realm;
-		};
-		29D8F8F3CDC97676551A1F67B07520E8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0431D34712EA2D1E2771AA4D24AB3848;
-			remoteInfo = AppSandboxFileAccess;
-		};
-		60CF1ADE211B8283EC097D1297B87E76 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F8DBBC6BB5AD1EBD4E9C618B36F18963;
-			remoteInfo = PathKit;
-		};
-		65FD849FE888931EF384B7D5C09AB7A5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1C77996166FA926760F5CA781567DE18;
-			remoteInfo = TGSpreadsheetWriter;
-		};
-		85F6C4400DDA8CC1C2E65D599B81C8DD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1C77996166FA926760F5CA781567DE18;
-			remoteInfo = TGSpreadsheetWriter;
-		};
-		A5B7328037649BCBEE8E293C6030C4BC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0DFDC22D11F2D25D7BC65BA79C0C8FC9;
-			remoteInfo = SSZipArchive;
-		};
-		B47485278D763CEF443861F6FBA92B65 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0DFDC22D11F2D25D7BC65BA79C0C8FC9;
-			remoteInfo = SSZipArchive;
-		};
-		BFA77BE3AF51AA10E6ED8EB65E333A31 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F8DBBC6BB5AD1EBD4E9C618B36F18963;
-			remoteInfo = PathKit;
-		};
-		C6362637BD272EAA7517AF82AFD5AB2B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C9289771C9E400167D4D291E44982A06;
-			remoteInfo = CSwiftV;
-		};
-		CFBF68BD3B74877080C303E00FC0C496 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D0CD4B404F898BAC414372B461A667BF;
-			remoteInfo = Realm;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXFileReference section */
-		03424E15C2D5A576CD2A2ED39E6C6E9B /* index_set.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = index_set.cpp; path = Realm/ObjectStore/index_set.cpp; sourceTree = "<group>"; };
-		04B964E9C58BE2B1D8E41942B9D7242E /* RLMProperty_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMProperty_Private.h; path = include/Realm/RLMProperty_Private.h; sourceTree = "<group>"; };
-		05A29D9811FE50FC553EE8380C12A459 /* ZipArchive.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ZipArchive.h; path = TGSpreadsheetWriter/ZipArchive.framework/Versions/A/Headers/ZipArchive.h; sourceTree = "<group>"; };
-		05C969245C1B62E7985DEA4377653C72 /* fileenc.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = fileenc.h; path = SSZipArchive/aes/fileenc.h; sourceTree = "<group>"; };
-		06C5909E9BA9F11BC60281FCB528DDC7 /* pwd2key.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pwd2key.c; path = SSZipArchive/aes/pwd2key.c; sourceTree = "<group>"; };
-		07894E49BED389CD196F901827EC6A19 /* RLMArray.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMArray.mm; path = Realm/RLMArray.mm; sourceTree = "<group>"; };
-		08F6E0C44E12D9CA8DF2DBC5866DE5B5 /* PathKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PathKit.xcconfig; sourceTree = "<group>"; };
-		0BB450E5051F002DCD6DF65F4C4F147F /* RLMRealm.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMRealm.mm; path = Realm/RLMRealm.mm; sourceTree = "<group>"; };
-		0C32BDA03399CEE008733EC4E942F5AB /* RLMAccessor.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMAccessor.mm; path = Realm/RLMAccessor.mm; sourceTree = "<group>"; };
-		0CBF82A7A39169D30B8A20E7229E7A18 /* AppSandboxFileAccess.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AppSandboxFileAccess.xcconfig; sourceTree = "<group>"; };
-		1020DC3FBB8E70DE1DAE17C97E85333E /* RLMMigration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMMigration.h; path = include/Realm/RLMMigration.h; sourceTree = "<group>"; };
-		1073FCE14723DD4CBB3C65F83CBF7FDF /* TGSpreadsheetWriter-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TGSpreadsheetWriter-prefix.pch"; sourceTree = "<group>"; };
-		111C0E4A52077D19B9B5AE075F686880 /* RLMAnalytics.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMAnalytics.mm; path = Realm/RLMAnalytics.mm; sourceTree = "<group>"; };
-		12189A8DE8928260ECB0D0A3B97ED120 /* librealm-macosx.a */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = archive.ar; name = "librealm-macosx.a"; path = "core/librealm-macosx.a"; sourceTree = "<group>"; };
-		127C0D709EA76419CDD3F71CB1C11EAD /* ImportSchema.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImportSchema.swift; path = RealmConverter/Schema/ImportSchema.swift; sourceTree = "<group>"; };
-		14EFD886E4361BC20FB65E7089303D8B /* RLMListBase.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMListBase.mm; path = Realm/RLMListBase.mm; sourceTree = "<group>"; };
-		1613577FE131ADE567FBD6DF6F3FDA70 /* RLMRealm.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMRealm.h; path = include/Realm/RLMRealm.h; sourceTree = "<group>"; };
-		17650893B51708A441A7FF79DEF2DAD0 /* AppSandboxFileAccess-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AppSandboxFileAccess-dummy.m"; sourceTree = "<group>"; };
-		1AE19F1FFD4B623527C27BF05D2BF31D /* schema.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = schema.cpp; path = Realm/ObjectStore/schema.cpp; sourceTree = "<group>"; };
-		1B394ACA1CE40F9DFC609B41FAA13E77 /* CSwiftV-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CSwiftV-prefix.pch"; sourceTree = "<group>"; };
-		1BA86B34A7ADF7C1260A7466874DD7D5 /* RLMUtil.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMUtil.mm; path = Realm/RLMUtil.mm; sourceTree = "<group>"; };
-		1C39AF29E5B53613D57105A4F510B0CD /* TGSpreadsheetWriter-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "TGSpreadsheetWriter-dummy.m"; sourceTree = "<group>"; };
-		1CAF6C55A82A67E4B3D1003CFB3369A9 /* RLMProperty.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMProperty.h; path = include/Realm/RLMProperty.h; sourceTree = "<group>"; };
-		1CE2B9AFFC43023F6FF64F38F3DBBECE /* ImportSchemaGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImportSchemaGenerator.swift; path = RealmConverter/Schema/ImportSchemaGenerator.swift; sourceTree = "<group>"; };
-		1D5BD286B05E51E6578C46A92D09BFC3 /* ioapi.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ioapi.h; path = SSZipArchive/minizip/ioapi.h; sourceTree = "<group>"; };
-		1DDDA9921A7144720EB431B6CAF58571 /* SSZipArchive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SSZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1E0615CF56088C501D87706816F66F05 /* RLMRealmConfiguration.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMRealmConfiguration.mm; path = Realm/RLMRealmConfiguration.mm; sourceTree = "<group>"; };
-		1E7BE00AFFDBDF6D840E2C8662F2BE42 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1EFED74A2EBBF8322E32677C9304BE56 /* RealmConverter-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RealmConverter-umbrella.h"; sourceTree = "<group>"; };
-		21B59C1A4A3C949D88977978CDDCD0DF /* RLMMigration_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMMigration_Private.h; path = include/Realm/RLMMigration_Private.h; sourceTree = "<group>"; };
-		24BB64FDE8E4F4C58C66185E955469AF /* RLMRealmConfiguration_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMRealmConfiguration_Private.h; path = include/Realm/RLMRealmConfiguration_Private.h; sourceTree = "<group>"; };
-		250D3DADF320E007F9BF93AB25F8A037 /* PathKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PathKit-umbrella.h"; sourceTree = "<group>"; };
-		27036DAD4BB60AF60BE6BC2BE2791BD7 /* CSVDataExporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CSVDataExporter.swift; path = RealmConverter/Exporter/CSVDataExporter.swift; sourceTree = "<group>"; };
-		27DB5238F29570F7A603A75A91C32A54 /* CSwiftV.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = CSwiftV.modulemap; sourceTree = "<group>"; };
-		2960CB11EBD6ADC737E702878E70B37C /* AppSandboxFileAccess.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = AppSandboxFileAccess.modulemap; sourceTree = "<group>"; };
-		2BCC458FDD5F692BBB2BFC64BB5701FC /* Pods-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-umbrella.h"; sourceTree = "<group>"; };
-		2E68AE67BA0144854548E9637BE351FF /* hmac.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hmac.h; path = SSZipArchive/aes/hmac.h; sourceTree = "<group>"; };
-		2E85BD6029B5A4E38247B8133FA951E9 /* PathKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PathKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2F441B555B2179F592E1CBA38663A808 /* aesopt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aesopt.h; path = SSZipArchive/aes/aesopt.h; sourceTree = "<group>"; };
-		2F99C81EE3FD403B46B3F5D39C6B71D0 /* aestab.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aestab.h; path = SSZipArchive/aes/aestab.h; sourceTree = "<group>"; };
-		31081229799E9933D1976C60F2B8AE47 /* aescrypt.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = aescrypt.c; path = SSZipArchive/aes/aescrypt.c; sourceTree = "<group>"; };
-		3198887C97EACA777370AE6F188AF829 /* mztools.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mztools.c; path = SSZipArchive/minizip/mztools.c; sourceTree = "<group>"; };
-		330511F3C7FE8CB73C875F331FB890D2 /* RealmConverter.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = RealmConverter.xcconfig; sourceTree = "<group>"; };
-		34784815C02C831E3E00AF383632BC0E /* TGSpreadsheetWriter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TGSpreadsheetWriter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3530DBF75398985B0150C5517334CD82 /* TGSpreadsheetWriter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = TGSpreadsheetWriter.m; path = TGSpreadsheetWriter/TGSpreadsheetWriter.m; sourceTree = "<group>"; };
-		355392CC6F82DB3D00CEF56FC4B53633 /* external_commit_helper.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = external_commit_helper.cpp; path = Realm/ObjectStore/impl/apple/external_commit_helper.cpp; sourceTree = "<group>"; };
-		35D92536BDC8AB8DEBA3A5613FC1BFFE /* ioapi.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = ioapi.c; path = SSZipArchive/minizip/ioapi.c; sourceTree = "<group>"; };
-		372D1E999518B8EE3D71FC3340D164A5 /* aes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aes.h; path = SSZipArchive/aes/aes.h; sourceTree = "<group>"; };
-		37EDB653332F73BE50868CAE1799508D /* RLMObjectBase.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMObjectBase.mm; path = Realm/RLMObjectBase.mm; sourceTree = "<group>"; };
-		3803D882518A91345A998713852DBFE9 /* RLMListBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMListBase.h; path = include/Realm/RLMListBase.h; sourceTree = "<group>"; };
-		3824AA76DE171EAD9ACF0C6BA55B45D3 /* RLMObjectSchema.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMObjectSchema.mm; path = Realm/RLMObjectSchema.mm; sourceTree = "<group>"; };
-		3B89A9461C52CD895C30943D4FF68AF9 /* AppSandboxFileAccess.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AppSandboxFileAccess.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3BD2BCEDFB78A820E986BC125AB99112 /* Common.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Common.h; path = TGSpreadsheetWriter/ZipArchive.framework/Versions/A/Headers/Common.h; sourceTree = "<group>"; };
-		3CC1D2825DD2D70DFC5C97B33482B657 /* TGSpreadsheetWriter.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = TGSpreadsheetWriter.modulemap; sourceTree = "<group>"; };
-		3F7A768A0AD58A0C9F06AA6725EF8BDA /* zip.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = zip.h; path = SSZipArchive/minizip/zip.h; sourceTree = "<group>"; };
-		40D1A523009273CD0AC912C47B7371A7 /* RealmConverter.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = RealmConverter.modulemap; sourceTree = "<group>"; };
-		4135B47426BBD4B027107FDD7DEFB3FB /* prng.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = prng.h; path = SSZipArchive/aes/prng.h; sourceTree = "<group>"; };
-		43103CF0EDC745ED1FABF936B4334F8D /* RLMConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMConstants.h; path = include/Realm/RLMConstants.h; sourceTree = "<group>"; };
-		44A1469F401CF6008E8A2F3F60BC10BD /* SSZipArchive-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SSZipArchive-umbrella.h"; sourceTree = "<group>"; };
-		44C604182F0C5BD5AB1B9EF2BD4B7D22 /* PathKit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PathKit.swift; path = Sources/PathKit.swift; sourceTree = "<group>"; };
-		4918C17F01E89C4D4A1EF222716F5C4C /* RLMSwiftSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RLMSwiftSupport.m; path = Realm/RLMSwiftSupport.m; sourceTree = "<group>"; };
-		4B1F27CAFD4C276D9D74B2A933F3CB45 /* RLMResults.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMResults.h; path = include/Realm/RLMResults.h; sourceTree = "<group>"; };
-		4B67266F7743232CEEA01857DEFCDC88 /* ZipArchive.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ZipArchive.h; path = SSZipArchive/ZipArchive.h; sourceTree = "<group>"; };
-		4E95F14A837F5530701D153685999E18 /* CSwiftV-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CSwiftV-umbrella.h"; sourceTree = "<group>"; };
-		4F76EFE18C9CC8BC88AE6DA1C782FE1C /* RLMRealmUtil.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMRealmUtil.mm; path = Realm/RLMRealmUtil.mm; sourceTree = "<group>"; };
-		52DFB13C140C3580E039585DE95F297C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		54C6E0D9A39100A1B977F6AA98B6B498 /* Common.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Common.h; path = SSZipArchive/Common.h; sourceTree = "<group>"; };
-		54C8EB611A0A77E462591BD7970E7968 /* cached_realm.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = cached_realm.cpp; path = Realm/ObjectStore/impl/apple/cached_realm.cpp; sourceTree = "<group>"; };
-		550A6586B95D3032173E6F1A20C6F049 /* PathKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PathKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		55EB30039FA973FA56CBC419DE912DC7 /* SSZipArchive.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SSZipArchive.h; path = TGSpreadsheetWriter/ZipArchive.framework/Versions/A/Headers/SSZipArchive.h; sourceTree = "<group>"; };
-		57095DD99474AD41DE3EEB4BE6F2D34E /* RealmConverter-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RealmConverter-prefix.pch"; sourceTree = "<group>"; };
-		594E74B6BCE69D8DD34926C7D82C9178 /* RLMAccessor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMAccessor.h; path = include/Realm/RLMAccessor.h; sourceTree = "<group>"; };
-		59F03CA5F870A59A7DC4FE571FF85A80 /* Realm.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Realm.h; path = include/Realm/Realm.h; sourceTree = "<group>"; };
-		5A24BC47325BB22483160927840DA2CC /* RLMUpdateChecker.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMUpdateChecker.mm; path = Realm/RLMUpdateChecker.mm; sourceTree = "<group>"; };
-		5C5DAF1B2F9D5EF96A9DDD60D0BB5BDC /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		5F10FF47841D4AAA329F613B6EC48340 /* RLMObject_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMObject_Private.h; path = include/Realm/RLMObject_Private.h; sourceTree = "<group>"; };
-		5F35DD12E0FAF85C747FB80152808849 /* TGSpreadsheetWriter-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TGSpreadsheetWriter-umbrella.h"; sourceTree = "<group>"; };
-		67085DAA3DC8DFB79CA4AFB23B88ED03 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		673F8575BD473AF5AF685151CDCC192A /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		68FF1B6FC0C6DE4F36B50D5E4E87AFF8 /* RLMObjectStore.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMObjectStore.h; path = include/Realm/RLMObjectStore.h; sourceTree = "<group>"; };
-		6B2A3090815002E3CB22D9C0833BB20D /* async_query.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = async_query.cpp; path = Realm/ObjectStore/impl/async_query.cpp; sourceTree = "<group>"; };
-		70153F79B788A90BC4A9E3679583D60D /* unzip.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = unzip.c; path = SSZipArchive/minizip/unzip.c; sourceTree = "<group>"; };
-		716C4A29792DD68A1977222812EEF84D /* aes_via_ace.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = aes_via_ace.h; path = SSZipArchive/aes/aes_via_ace.h; sourceTree = "<group>"; };
-		71C39ECE6DDDADF5E1A4F45352B339E4 /* DataImporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DataImporter.swift; path = RealmConverter/Importer/DataImporter.swift; sourceTree = "<group>"; };
-		7210605A669DE89C7D8A5F4395EEAD7E /* RLMSchema.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMSchema.mm; path = Realm/RLMSchema.mm; sourceTree = "<group>"; };
-		72176F811D85F6AE2E7BF90CBD601644 /* CSwiftV.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CSwiftV.swift; path = CSwiftV/CSwiftV.swift; sourceTree = "<group>"; };
-		745CFE9844D5ADA3FA496AF4EA9A2391 /* CSwiftV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CSwiftV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		79764CC7086366871B7D1D089EE9CEDE /* ImportObjectSchema.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImportObjectSchema.swift; path = RealmConverter/Schema/ImportObjectSchema.swift; sourceTree = "<group>"; };
-		79A9DEDC89FE8336BF5FEDAAF75BF7FC /* Pods.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Pods.modulemap; sourceTree = "<group>"; };
-		7AC5F2A74AE518C6C97ED0BDB2B27333 /* Realm.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Realm.xcconfig; sourceTree = "<group>"; };
-		7B77BF0083B2A3FE0247DC63E8C16CA0 /* RLMSchema.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMSchema.h; path = include/Realm/RLMSchema.h; sourceTree = "<group>"; };
-		7B946225F6DC665FBE058EB6B9C7A641 /* Realm-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Realm-prefix.pch"; sourceTree = "<group>"; };
-		7C6E2396FEF3F056166688C4BFD133CE /* sha1.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sha1.h; path = SSZipArchive/aes/sha1.h; sourceTree = "<group>"; };
-		7CF4D42A8F0D4F169E76D4E90E5C74C0 /* SSZipArchive.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SSZipArchive.h; path = SSZipArchive/SSZipArchive.h; sourceTree = "<group>"; };
-		7DCBCBCB4B46B50367FA4493659182A3 /* SSZipArchive.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SSZipArchive.modulemap; sourceTree = "<group>"; };
-		7F457A03F9AAC050288B25C55486010D /* RLMObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMObject.h; path = include/Realm/RLMObject.h; sourceTree = "<group>"; };
-		82EF335C7BBCC60AEE64B430F4B9DF08 /* CSwiftV.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CSwiftV.xcconfig; sourceTree = "<group>"; };
-		86961DC4D50C3885E3F4A6B9039F2554 /* prng.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = prng.c; path = SSZipArchive/aes/prng.c; sourceTree = "<group>"; };
-		87B213035BAC5F75386F62D3C75D2342 /* Pods-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-acknowledgements.plist"; sourceTree = "<group>"; };
-		8803880F9B2DEDE45EBF1B8ECE83A699 /* object_store.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = object_store.cpp; path = Realm/ObjectStore/object_store.cpp; sourceTree = "<group>"; };
-		894E5DA93A9F359521A89826BE6DA777 /* Pods-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-dummy.m"; sourceTree = "<group>"; };
-		89F0037B1208F4778B38B0CFF68348A7 /* entropy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = entropy.h; path = SSZipArchive/aes/entropy.h; sourceTree = "<group>"; };
-		8A26F9EF39256FD631BD62725E2402F7 /* TGSpreadsheetWriter.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TGSpreadsheetWriter.xcconfig; sourceTree = "<group>"; };
-		8A293A690C61C7D33120456C1774581A /* CSwiftV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CSwiftV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A4E5A63C89400E1B3EE4D720E49F86F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8B7EFFBC7FFCD4E65241A123E257CF7F /* entropy.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = entropy.c; path = SSZipArchive/aes/entropy.c; sourceTree = "<group>"; };
-		95420313339AF991DDC48B242C068AB0 /* shared_realm.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = shared_realm.cpp; path = Realm/ObjectStore/shared_realm.cpp; sourceTree = "<group>"; };
-		963D87FDD08BED60C7AAD8238A147DD1 /* Realm.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Realm.modulemap; sourceTree = "<group>"; };
-		977577C045EDA9D9D1F46E2598D19FC7 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.debug.xcconfig; sourceTree = "<group>"; };
-		999C6BE75E407953D138E873E91D3E21 /* RLMRealmConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMRealmConfiguration.h; path = include/Realm/RLMRealmConfiguration.h; sourceTree = "<group>"; };
-		9A5A17348B4D0E60ABAA4D040EA8DFED /* object_schema.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = object_schema.cpp; path = Realm/ObjectStore/object_schema.cpp; sourceTree = "<group>"; };
-		9ABC69341A34F40BBD661AE423D06E3E /* RLMOptionalBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMOptionalBase.h; path = include/Realm/RLMOptionalBase.h; sourceTree = "<group>"; };
-		9C1E65AD80D079676A8F578109A642BC /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9C322452B27A96368ACC916DB4EACE9D /* SSZipArchive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SSZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9C757FF507346A6EB9D2540C8E620D79 /* Realm.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Realm.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9E563B38E40DB43E6C8718B0C2BE9E2A /* RealmConverter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RealmConverter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9E8AD47E2D34FE19688243E5F1328F63 /* Realm.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Realm.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A02FB283C242F581628F1E1860C29BA3 /* RLMArrayLinkView.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMArrayLinkView.mm; path = Realm/RLMArrayLinkView.mm; sourceTree = "<group>"; };
-		A042AC754D95496EB6398473225A7078 /* AppSandboxFileAccessPersist.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AppSandboxFileAccessPersist.h; path = AppSandboxFileAccess/Classes/AppSandboxFileAccessPersist.h; sourceTree = "<group>"; };
-		A0496BBB3CF3A07D65946972DDCB906C /* RLMDefines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMDefines.h; path = include/Realm/RLMDefines.h; sourceTree = "<group>"; };
-		A086A964EFA9C3A7879C3129B759FFCE /* AppSandboxFileAccess.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AppSandboxFileAccess.m; path = AppSandboxFileAccess/Classes/AppSandboxFileAccess.m; sourceTree = "<group>"; };
-		A19421B9966A85C3EAC8DDC4FBCFCAF9 /* RLMProperty.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMProperty.mm; path = Realm/RLMProperty.mm; sourceTree = "<group>"; };
-		A1DA738A84039E33733961E6B3E317D9 /* AppSandboxFileAccessPersist.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AppSandboxFileAccessPersist.m; path = AppSandboxFileAccess/Classes/AppSandboxFileAccessPersist.m; sourceTree = "<group>"; };
-		A2E224763DAA078EE22DC2EF01A9B1F6 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
-		A30A2A989CC72FB4D46E1C18FEAC1E4B /* RLMObjectSchema.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMObjectSchema.h; path = include/Realm/RLMObjectSchema.h; sourceTree = "<group>"; };
-		A3F3D3E4246FB153A3C238A0890D8C7A /* RLMObjectStore.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMObjectStore.mm; path = Realm/RLMObjectStore.mm; sourceTree = "<group>"; };
-		A5A585A14DEE51BD017795B9A5BFF371 /* AppSandboxFileAccessOpenSavePanelDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AppSandboxFileAccessOpenSavePanelDelegate.h; path = AppSandboxFileAccess/Classes/AppSandboxFileAccessOpenSavePanelDelegate.h; sourceTree = "<group>"; };
-		A68A5681C548CA29D8B6854F430B46FA /* RLMArray.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMArray.h; path = include/Realm/RLMArray.h; sourceTree = "<group>"; };
-		A8429AF4EF3E7FBCBE758A1200B23AE7 /* aeskey.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = aeskey.c; path = SSZipArchive/aes/aeskey.c; sourceTree = "<group>"; };
-		A878C683463E5D95C28E7DF9A2068391 /* AppSandboxFileAccessOpenSavePanelDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AppSandboxFileAccessOpenSavePanelDelegate.m; path = AppSandboxFileAccess/Classes/AppSandboxFileAccessOpenSavePanelDelegate.m; sourceTree = "<group>"; };
-		A970B9FC0E0B15EB134A53D39BA938E3 /* RLMCollection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMCollection.h; path = include/Realm/RLMCollection.h; sourceTree = "<group>"; };
-		AA353BA701BC4981916B046E80579AFF /* brg_endian.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = brg_endian.h; path = SSZipArchive/aes/brg_endian.h; sourceTree = "<group>"; };
-		AAE0D156249D94D4B7EA6573E78BECF5 /* pwd2key.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pwd2key.h; path = SSZipArchive/aes/pwd2key.h; sourceTree = "<group>"; };
-		AB0FBCDE4D353AAC203D8510CD88849D /* RLMPlatform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMPlatform.h; path = include/Realm/RLMPlatform.h; sourceTree = "<group>"; };
-		AC4DB82A899509932498571314464BF1 /* SSZipArchive-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SSZipArchive-prefix.pch"; sourceTree = "<group>"; };
-		AFFAACC04CCAFAC7EF65AE188FFE14F6 /* SSZipArchive.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SSZipArchive.m; path = SSZipArchive/SSZipArchive.m; sourceTree = "<group>"; };
-		B1ECB794421C4581658AE60E13BEA337 /* Encoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Encoding.swift; path = RealmConverter/Support/Encoding.swift; sourceTree = "<group>"; };
-		B1FCEDB643FAF9E812BD22FC813BA25A /* AppSandboxFileAccess-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AppSandboxFileAccess-umbrella.h"; sourceTree = "<group>"; };
-		B21FF966A642F7DF524A2FFD92271B27 /* CSVDataImporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CSVDataImporter.swift; path = RealmConverter/Importer/CSVDataImporter.swift; sourceTree = "<group>"; };
-		B4231AE1512289C8EA19666DD531F5B4 /* crypt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = crypt.h; path = SSZipArchive/minizip/crypt.h; sourceTree = "<group>"; };
-		B52762951A1DBC3E77A33ABD829FEE0D /* results.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = results.cpp; path = Realm/ObjectStore/results.cpp; sourceTree = "<group>"; };
-		B53D6206CA911D031F8053FC6636C7B1 /* SSZipArchive-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SSZipArchive-dummy.m"; sourceTree = "<group>"; };
-		B71ABEDF6A3C3AA1CC4AC880C7BC8A86 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B8AE37511CF793AD65D0B6411DE3C4D1 /* RLMObjectBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMObjectBase.h; path = include/Realm/RLMObjectBase.h; sourceTree = "<group>"; };
-		B8C4745957C099E9682B5181B1928187 /* hmac.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = hmac.c; path = SSZipArchive/aes/hmac.c; sourceTree = "<group>"; };
-		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		BD25BCAEC40792D702B165DC4E0E4068 /* RLMObjectBase_Dynamic.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMObjectBase_Dynamic.h; path = include/Realm/RLMObjectBase_Dynamic.h; sourceTree = "<group>"; };
-		BF080C07656878AAB4897C2BBFA46B13 /* RLMConstants.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RLMConstants.m; path = Realm/RLMConstants.m; sourceTree = "<group>"; };
-		C0ED6A24D351EA7318641F59FA8CC831 /* DataExporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DataExporter.swift; path = RealmConverter/Exporter/DataExporter.swift; sourceTree = "<group>"; };
-		C1B856FA1794963765B6B11447040661 /* RLMObservation.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMObservation.mm; path = Realm/RLMObservation.mm; sourceTree = "<group>"; };
-		C3C4E3105B0FA8266054F37B2AE56540 /* RLMArray_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMArray_Private.h; path = include/Realm/RLMArray_Private.h; sourceTree = "<group>"; };
-		C4B83AB3AD2940C100050FC255571F5B /* RLMObjectSchema_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMObjectSchema_Private.h; path = include/Realm/RLMObjectSchema_Private.h; sourceTree = "<group>"; };
-		C5504A46EA0B3A6D2FE2C3911CDFACA4 /* RLMResults_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMResults_Private.h; path = include/Realm/RLMResults_Private.h; sourceTree = "<group>"; };
-		C7DE9DCC709D99E2D78137CE68DA06EB /* sha1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = sha1.c; path = SSZipArchive/aes/sha1.c; sourceTree = "<group>"; };
-		C8CC732936FA19529773DD3C751FFF2C /* SSZipArchive.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SSZipArchive.xcconfig; sourceTree = "<group>"; };
-		C9200253A8AE36C3AB6DEFE3AC62C075 /* RealmConverter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RealmConverter.h; path = RealmConverter/RealmConverter.h; sourceTree = "<group>"; };
-		CAD5C8EFBD82FCA7F4C711DDCE626676 /* XLSXDataImporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XLSXDataImporter.swift; path = RealmConverter/Importer/XLSXDataImporter.swift; sourceTree = "<group>"; };
-		CBC0335B8B9B9D0BA1CC6AF6495929D9 /* RLMRealm_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMRealm_Private.h; path = include/Realm/RLMRealm_Private.h; sourceTree = "<group>"; };
-		CBC0F7C552B739C909B650A0F42F7F38 /* Pods-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-resources.sh"; sourceTree = "<group>"; };
-		D0405803033A2A777B8E4DFA0C1800ED /* Pods-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-acknowledgements.markdown"; sourceTree = "<group>"; };
-		D24235CDF995FC31A2897A5A7283FC5E /* RLMMigration.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMMigration.mm; path = Realm/RLMMigration.mm; sourceTree = "<group>"; };
-		D5165BCE41EC813689C4C6F4F29CC3C6 /* AppSandboxFileAccess.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AppSandboxFileAccess.h; path = AppSandboxFileAccess/Classes/AppSandboxFileAccess.h; sourceTree = "<group>"; };
-		DA312349A49333542E6F4B36B329960E /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.release.xcconfig; sourceTree = "<group>"; };
-		DAB7D91BBCF663D88A2F0482906EB695 /* RLMObject.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMObject.mm; path = Realm/RLMObject.mm; sourceTree = "<group>"; };
-		DB255E01E754531C0F73C07C6ECAACC1 /* RLMQueryUtil.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMQueryUtil.mm; path = Realm/RLMQueryUtil.mm; sourceTree = "<group>"; };
-		DBB05F4BA4BADCFFC489810FA229A121 /* String+CamelCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+CamelCase.swift"; path = "RealmConverter/Support/String+CamelCase.swift"; sourceTree = "<group>"; };
-		DBE7F0C00830063060771EF7F00929D9 /* CSwiftV-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CSwiftV-dummy.m"; sourceTree = "<group>"; };
-		DCE2B1A050EB5CEEA7ADDCD3C05F54E0 /* RLMSchema_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMSchema_Private.h; path = include/Realm/RLMSchema_Private.h; sourceTree = "<group>"; };
-		DE7AD83A17E01FB317130543AB9C44A6 /* mztools.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mztools.h; path = SSZipArchive/minizip/mztools.h; sourceTree = "<group>"; };
-		DFA0C81489C637F0DA69EB1F54B6AEE5 /* RLMResults.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMResults.mm; path = Realm/RLMResults.mm; sourceTree = "<group>"; };
-		E22CE0498E06FD67D741E59D96E720A5 /* aestab.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = aestab.c; path = SSZipArchive/aes/aestab.c; sourceTree = "<group>"; };
-		E3CD6EF222114C791F5F8A6F461A0C2D /* PathKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PathKit-dummy.m"; sourceTree = "<group>"; };
-		E7F21354943D9F42A70697D5A5EF72E9 /* Pods-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-frameworks.sh"; sourceTree = "<group>"; };
-		E8446514FBAD26C0E18F24A5715AEF67 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E84A16B2DD844599EC3037DA81D2038D /* RLMPredicateUtil.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMPredicateUtil.mm; path = Realm/RLMPredicateUtil.mm; sourceTree = "<group>"; };
-		ED8762338AC853B059F0078B7BF54C74 /* realm_coordinator.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = realm_coordinator.cpp; path = Realm/ObjectStore/impl/realm_coordinator.cpp; sourceTree = "<group>"; };
-		EDAA7BD525EAC1621E00BCBC3E8C1EC5 /* RLMRealm_Dynamic.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RLMRealm_Dynamic.h; path = include/Realm/RLMRealm_Dynamic.h; sourceTree = "<group>"; };
-		EE34A6272512B232D721068FFE5A4D78 /* brg_types.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = brg_types.h; path = SSZipArchive/aes/brg_types.h; sourceTree = "<group>"; };
-		F12D867DADEF9CF1B5E8F866B13DFF9B /* TGSpreadsheetWriter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = TGSpreadsheetWriter.h; path = TGSpreadsheetWriter/TGSpreadsheetWriter.h; sourceTree = "<group>"; };
-		F42F2F73B04A3EC00CF51F753925309C /* TGSpreadsheetWriter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TGSpreadsheetWriter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F49D90E43BEB2AA8A737BADDCBAA3087 /* Realm-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Realm-dummy.m"; sourceTree = "<group>"; };
-		F4E4D5458A3957A50C451BDD460A8146 /* unzip.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = unzip.h; path = SSZipArchive/minizip/unzip.h; sourceTree = "<group>"; };
-		F52EC04D9DC0AE2842735C7D17BD3787 /* transact_log_handler.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = transact_log_handler.cpp; path = Realm/ObjectStore/impl/transact_log_handler.cpp; sourceTree = "<group>"; };
-		FA2B9B51D5095FB9B92784C1A76782D5 /* AppSandboxFileAccess-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AppSandboxFileAccess-prefix.pch"; sourceTree = "<group>"; };
-		FB4F8753DB9E04DEF61E0036DF03A9D5 /* PathKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PathKit-prefix.pch"; sourceTree = "<group>"; };
-		FC6DA370156B0CC5579A4EB40228B09A /* PathKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = PathKit.modulemap; sourceTree = "<group>"; };
-		FC70D2C69CFEAFBE595CF4B7A74BF947 /* RLMOptionalBase.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMOptionalBase.mm; path = Realm/RLMOptionalBase.mm; sourceTree = "<group>"; };
-		FD499AC05B2273EEBB6CCEACDFB0D19A /* zip.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = zip.c; path = SSZipArchive/minizip/zip.c; sourceTree = "<group>"; };
-		FD49C997C594336277C7D44719D71E59 /* fileenc.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fileenc.c; path = SSZipArchive/aes/fileenc.c; sourceTree = "<group>"; };
-		FEC311E12DB84B8600A60E9FBA3799E0 /* RealmConverter-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "RealmConverter-dummy.m"; sourceTree = "<group>"; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		5A32B536D41A7FF3766372F2865CBCF5 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				EC4E64AD48AAF9E2943ACB390398369A /* Cocoa.framework in Frameworks */,
-				E1AC9B1FE18A1562F9378EC7DFAD8648 /* SSZipArchive.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8621E5C1CB20FA11CB771D77FB7B3AD2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				4FC442CF7DD73E52ECFD60891097F2AE /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		88E202801384BBC86FDF42C356851E19 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C238473D12590CFD4363445513344DFB /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8E431233EAF533E1266BDF234908FE0D /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				5F702A59D013D9F682E348CA76AEE172 /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A1F85F7C52B80C457B84DCE87858EF1D /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				AB463BFDEF905F5059456498455BECEA /* Cocoa.framework in Frameworks */,
-				AF05BE9D1B49B2BFE46731DBC4D3B017 /* CSwiftV.framework in Frameworks */,
-				CBAD2B66321765D0F602D8546BA70B86 /* PathKit.framework in Frameworks */,
-				839C6F803412E9E34416A049CB85BD85 /* Realm.framework in Frameworks */,
-				904335DE07D1D67885592BA72317EEAC /* TGSpreadsheetWriter.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EAE26F5FFCA07C906946B3B3354CD3F3 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C95637F789EB1F555F898F9A90279731 /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F2F5C77F6B8A82BE8F99A87FC3F189A7 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				89D13F76001C05818D50C48B10052874 /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FDE4BD31022A5A84F0CA297BF78DC225 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				92C77F228BD83616B71F63BD4DB0E24A /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		0126D3CD668280339023A015BBF887A5 /* CSwiftV */ = {
-			isa = PBXGroup;
-			children = (
-				72176F811D85F6AE2E7BF90CBD601644 /* CSwiftV.swift */,
-				DA9DB603212261629EE155B9D9953AEB /* Support Files */,
-			);
-			path = CSwiftV;
-			sourceTree = "<group>";
-		};
-		16669CB94E13E0E2A56357B5A990584E /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				94DF76D80C35A421434CADCC0FA98700 /* AppSandboxFileAccess */,
-				0126D3CD668280339023A015BBF887A5 /* CSwiftV */,
-				4F948398FE4B95997689935C8B532ADA /* PathKit */,
-				4E6EC8A776A5FB4C53472CEB067DB690 /* Realm */,
-				3A43C812EB4F68034C7C671B29CD5982 /* RealmConverter */,
-				F5263B7FB0B4EF6A2110479832023FF8 /* SSZipArchive */,
-				9C4C5DD30F6807E5CAA0686C21363E4C /* TGSpreadsheetWriter */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		3935171316CB2D6D538FF51A2757F251 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				2960CB11EBD6ADC737E702878E70B37C /* AppSandboxFileAccess.modulemap */,
-				0CBF82A7A39169D30B8A20E7229E7A18 /* AppSandboxFileAccess.xcconfig */,
-				17650893B51708A441A7FF79DEF2DAD0 /* AppSandboxFileAccess-dummy.m */,
-				FA2B9B51D5095FB9B92784C1A76782D5 /* AppSandboxFileAccess-prefix.pch */,
-				B1FCEDB643FAF9E812BD22FC813BA25A /* AppSandboxFileAccess-umbrella.h */,
-				B71ABEDF6A3C3AA1CC4AC880C7BC8A86 /* Info.plist */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/AppSandboxFileAccess";
-			sourceTree = "<group>";
-		};
-		3A43C812EB4F68034C7C671B29CD5982 /* RealmConverter */ = {
-			isa = PBXGroup;
-			children = (
-				27036DAD4BB60AF60BE6BC2BE2791BD7 /* CSVDataExporter.swift */,
-				B21FF966A642F7DF524A2FFD92271B27 /* CSVDataImporter.swift */,
-				C0ED6A24D351EA7318641F59FA8CC831 /* DataExporter.swift */,
-				71C39ECE6DDDADF5E1A4F45352B339E4 /* DataImporter.swift */,
-				B1ECB794421C4581658AE60E13BEA337 /* Encoding.swift */,
-				79764CC7086366871B7D1D089EE9CEDE /* ImportObjectSchema.swift */,
-				127C0D709EA76419CDD3F71CB1C11EAD /* ImportSchema.swift */,
-				1CE2B9AFFC43023F6FF64F38F3DBBECE /* ImportSchemaGenerator.swift */,
-				C9200253A8AE36C3AB6DEFE3AC62C075 /* RealmConverter.h */,
-				DBB05F4BA4BADCFFC489810FA229A121 /* String+CamelCase.swift */,
-				CAD5C8EFBD82FCA7F4C711DDCE626676 /* XLSXDataImporter.swift */,
-				B15FBB607E84631F78CA08362B96CCFC /* Support Files */,
-			);
-			path = RealmConverter;
-			sourceTree = "<group>";
-		};
-		4D9F3C0F8F127C1F302BA2C94EBD2AC6 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				3B89A9461C52CD895C30943D4FF68AF9 /* AppSandboxFileAccess.framework */,
-				8A293A690C61C7D33120456C1774581A /* CSwiftV.framework */,
-				550A6586B95D3032173E6F1A20C6F049 /* PathKit.framework */,
-				1E7BE00AFFDBDF6D840E2C8662F2BE42 /* Pods.framework */,
-				9E8AD47E2D34FE19688243E5F1328F63 /* Realm.framework */,
-				9E563B38E40DB43E6C8718B0C2BE9E2A /* RealmConverter.framework */,
-				9C322452B27A96368ACC916DB4EACE9D /* SSZipArchive.framework */,
-				34784815C02C831E3E00AF383632BC0E /* TGSpreadsheetWriter.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		4E6EC8A776A5FB4C53472CEB067DB690 /* Realm */ = {
-			isa = PBXGroup;
-			children = (
-				6B2A3090815002E3CB22D9C0833BB20D /* async_query.cpp */,
-				54C8EB611A0A77E462591BD7970E7968 /* cached_realm.cpp */,
-				355392CC6F82DB3D00CEF56FC4B53633 /* external_commit_helper.cpp */,
-				03424E15C2D5A576CD2A2ED39E6C6E9B /* index_set.cpp */,
-				9A5A17348B4D0E60ABAA4D040EA8DFED /* object_schema.cpp */,
-				8803880F9B2DEDE45EBF1B8ECE83A699 /* object_store.cpp */,
-				ED8762338AC853B059F0078B7BF54C74 /* realm_coordinator.cpp */,
-				B52762951A1DBC3E77A33ABD829FEE0D /* results.cpp */,
-				594E74B6BCE69D8DD34926C7D82C9178 /* RLMAccessor.h */,
-				0C32BDA03399CEE008733EC4E942F5AB /* RLMAccessor.mm */,
-				111C0E4A52077D19B9B5AE075F686880 /* RLMAnalytics.mm */,
-				07894E49BED389CD196F901827EC6A19 /* RLMArray.mm */,
-				C3C4E3105B0FA8266054F37B2AE56540 /* RLMArray_Private.h */,
-				A02FB283C242F581628F1E1860C29BA3 /* RLMArrayLinkView.mm */,
-				BF080C07656878AAB4897C2BBFA46B13 /* RLMConstants.m */,
-				3803D882518A91345A998713852DBFE9 /* RLMListBase.h */,
-				14EFD886E4361BC20FB65E7089303D8B /* RLMListBase.mm */,
-				D24235CDF995FC31A2897A5A7283FC5E /* RLMMigration.mm */,
-				21B59C1A4A3C949D88977978CDDCD0DF /* RLMMigration_Private.h */,
-				DAB7D91BBCF663D88A2F0482906EB695 /* RLMObject.mm */,
-				5F10FF47841D4AAA329F613B6EC48340 /* RLMObject_Private.h */,
-				37EDB653332F73BE50868CAE1799508D /* RLMObjectBase.mm */,
-				3824AA76DE171EAD9ACF0C6BA55B45D3 /* RLMObjectSchema.mm */,
-				C4B83AB3AD2940C100050FC255571F5B /* RLMObjectSchema_Private.h */,
-				68FF1B6FC0C6DE4F36B50D5E4E87AFF8 /* RLMObjectStore.h */,
-				A3F3D3E4246FB153A3C238A0890D8C7A /* RLMObjectStore.mm */,
-				C1B856FA1794963765B6B11447040661 /* RLMObservation.mm */,
-				9ABC69341A34F40BBD661AE423D06E3E /* RLMOptionalBase.h */,
-				FC70D2C69CFEAFBE595CF4B7A74BF947 /* RLMOptionalBase.mm */,
-				E84A16B2DD844599EC3037DA81D2038D /* RLMPredicateUtil.mm */,
-				A19421B9966A85C3EAC8DDC4FBCFCAF9 /* RLMProperty.mm */,
-				04B964E9C58BE2B1D8E41942B9D7242E /* RLMProperty_Private.h */,
-				DB255E01E754531C0F73C07C6ECAACC1 /* RLMQueryUtil.mm */,
-				0BB450E5051F002DCD6DF65F4C4F147F /* RLMRealm.mm */,
-				CBC0335B8B9B9D0BA1CC6AF6495929D9 /* RLMRealm_Private.h */,
-				1E0615CF56088C501D87706816F66F05 /* RLMRealmConfiguration.mm */,
-				24BB64FDE8E4F4C58C66185E955469AF /* RLMRealmConfiguration_Private.h */,
-				4F76EFE18C9CC8BC88AE6DA1C782FE1C /* RLMRealmUtil.mm */,
-				DFA0C81489C637F0DA69EB1F54B6AEE5 /* RLMResults.mm */,
-				C5504A46EA0B3A6D2FE2C3911CDFACA4 /* RLMResults_Private.h */,
-				7210605A669DE89C7D8A5F4395EEAD7E /* RLMSchema.mm */,
-				DCE2B1A050EB5CEEA7ADDCD3C05F54E0 /* RLMSchema_Private.h */,
-				4918C17F01E89C4D4A1EF222716F5C4C /* RLMSwiftSupport.m */,
-				5A24BC47325BB22483160927840DA2CC /* RLMUpdateChecker.mm */,
-				1BA86B34A7ADF7C1260A7466874DD7D5 /* RLMUtil.mm */,
-				1AE19F1FFD4B623527C27BF05D2BF31D /* schema.cpp */,
-				95420313339AF991DDC48B242C068AB0 /* shared_realm.cpp */,
-				F52EC04D9DC0AE2842735C7D17BD3787 /* transact_log_handler.cpp */,
-				E8004BC3C383BE4026064214ABE245DD /* Frameworks */,
-				9A88B67BA53DC06138354AE4AB06BBEC /* Headers */,
-				7602C62CAAF32D05AEA4475DD82A9B27 /* Support Files */,
-			);
-			path = Realm;
-			sourceTree = "<group>";
-		};
-		4F948398FE4B95997689935C8B532ADA /* PathKit */ = {
-			isa = PBXGroup;
-			children = (
-				44C604182F0C5BD5AB1B9EF2BD4B7D22 /* PathKit.swift */,
-				976B681CB49490257B24B748167EE9F5 /* Support Files */,
-			);
-			path = PathKit;
-			sourceTree = "<group>";
-		};
-		571D4F3D11A96E570A814E7D4A3A17BE /* OS X */ = {
-			isa = PBXGroup;
-			children = (
-				A2E224763DAA078EE22DC2EF01A9B1F6 /* Cocoa.framework */,
-			);
-			name = "OS X";
-			sourceTree = "<group>";
-		};
-		5D8256413F416A8B75806ABA3C35E42B /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				745CFE9844D5ADA3FA496AF4EA9A2391 /* CSwiftV.framework */,
-				2E85BD6029B5A4E38247B8133FA951E9 /* PathKit.framework */,
-				9C757FF507346A6EB9D2540C8E620D79 /* Realm.framework */,
-				1DDDA9921A7144720EB431B6CAF58571 /* SSZipArchive.framework */,
-				F42F2F73B04A3EC00CF51F753925309C /* TGSpreadsheetWriter.framework */,
-				571D4F3D11A96E570A814E7D4A3A17BE /* OS X */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		75D98FF52E597A11900E131B6C4E1ADA /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				E8446514FBAD26C0E18F24A5715AEF67 /* Info.plist */,
-				79A9DEDC89FE8336BF5FEDAAF75BF7FC /* Pods.modulemap */,
-				D0405803033A2A777B8E4DFA0C1800ED /* Pods-acknowledgements.markdown */,
-				87B213035BAC5F75386F62D3C75D2342 /* Pods-acknowledgements.plist */,
-				894E5DA93A9F359521A89826BE6DA777 /* Pods-dummy.m */,
-				E7F21354943D9F42A70697D5A5EF72E9 /* Pods-frameworks.sh */,
-				CBC0F7C552B739C909B650A0F42F7F38 /* Pods-resources.sh */,
-				2BCC458FDD5F692BBB2BFC64BB5701FC /* Pods-umbrella.h */,
-				977577C045EDA9D9D1F46E2598D19FC7 /* Pods.debug.xcconfig */,
-				DA312349A49333542E6F4B36B329960E /* Pods.release.xcconfig */,
-			);
-			name = Pods;
-			path = "Target Support Files/Pods";
-			sourceTree = "<group>";
-		};
-		7602C62CAAF32D05AEA4475DD82A9B27 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				67085DAA3DC8DFB79CA4AFB23B88ED03 /* Info.plist */,
-				963D87FDD08BED60C7AAD8238A147DD1 /* Realm.modulemap */,
-				7AC5F2A74AE518C6C97ED0BDB2B27333 /* Realm.xcconfig */,
-				F49D90E43BEB2AA8A737BADDCBAA3087 /* Realm-dummy.m */,
-				7B946225F6DC665FBE058EB6B9C7A641 /* Realm-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Realm";
-			sourceTree = "<group>";
-		};
-		7DB346D0F39D3F0E887471402A8071AB = {
-			isa = PBXGroup;
-			children = (
-				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
-				5D8256413F416A8B75806ABA3C35E42B /* Frameworks */,
-				16669CB94E13E0E2A56357B5A990584E /* Pods */,
-				4D9F3C0F8F127C1F302BA2C94EBD2AC6 /* Products */,
-				B7B80995527643776607AFFA75B91E24 /* Targets Support Files */,
-			);
-			sourceTree = "<group>";
-		};
-		94DF76D80C35A421434CADCC0FA98700 /* AppSandboxFileAccess */ = {
-			isa = PBXGroup;
-			children = (
-				D5165BCE41EC813689C4C6F4F29CC3C6 /* AppSandboxFileAccess.h */,
-				A086A964EFA9C3A7879C3129B759FFCE /* AppSandboxFileAccess.m */,
-				A5A585A14DEE51BD017795B9A5BFF371 /* AppSandboxFileAccessOpenSavePanelDelegate.h */,
-				A878C683463E5D95C28E7DF9A2068391 /* AppSandboxFileAccessOpenSavePanelDelegate.m */,
-				A042AC754D95496EB6398473225A7078 /* AppSandboxFileAccessPersist.h */,
-				A1DA738A84039E33733961E6B3E317D9 /* AppSandboxFileAccessPersist.m */,
-				3935171316CB2D6D538FF51A2757F251 /* Support Files */,
-			);
-			path = AppSandboxFileAccess;
-			sourceTree = "<group>";
-		};
-		976B681CB49490257B24B748167EE9F5 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				8A4E5A63C89400E1B3EE4D720E49F86F /* Info.plist */,
-				FC6DA370156B0CC5579A4EB40228B09A /* PathKit.modulemap */,
-				08F6E0C44E12D9CA8DF2DBC5866DE5B5 /* PathKit.xcconfig */,
-				E3CD6EF222114C791F5F8A6F461A0C2D /* PathKit-dummy.m */,
-				FB4F8753DB9E04DEF61E0036DF03A9D5 /* PathKit-prefix.pch */,
-				250D3DADF320E007F9BF93AB25F8A037 /* PathKit-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/PathKit";
-			sourceTree = "<group>";
-		};
-		9A88B67BA53DC06138354AE4AB06BBEC /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				59F03CA5F870A59A7DC4FE571FF85A80 /* Realm.h */,
-				A68A5681C548CA29D8B6854F430B46FA /* RLMArray.h */,
-				A970B9FC0E0B15EB134A53D39BA938E3 /* RLMCollection.h */,
-				43103CF0EDC745ED1FABF936B4334F8D /* RLMConstants.h */,
-				A0496BBB3CF3A07D65946972DDCB906C /* RLMDefines.h */,
-				1020DC3FBB8E70DE1DAE17C97E85333E /* RLMMigration.h */,
-				7F457A03F9AAC050288B25C55486010D /* RLMObject.h */,
-				B8AE37511CF793AD65D0B6411DE3C4D1 /* RLMObjectBase.h */,
-				BD25BCAEC40792D702B165DC4E0E4068 /* RLMObjectBase_Dynamic.h */,
-				A30A2A989CC72FB4D46E1C18FEAC1E4B /* RLMObjectSchema.h */,
-				AB0FBCDE4D353AAC203D8510CD88849D /* RLMPlatform.h */,
-				1CAF6C55A82A67E4B3D1003CFB3369A9 /* RLMProperty.h */,
-				1613577FE131ADE567FBD6DF6F3FDA70 /* RLMRealm.h */,
-				EDAA7BD525EAC1621E00BCBC3E8C1EC5 /* RLMRealm_Dynamic.h */,
-				999C6BE75E407953D138E873E91D3E21 /* RLMRealmConfiguration.h */,
-				4B1F27CAFD4C276D9D74B2A933F3CB45 /* RLMResults.h */,
-				7B77BF0083B2A3FE0247DC63E8C16CA0 /* RLMSchema.h */,
-			);
-			name = Headers;
-			sourceTree = "<group>";
-		};
-		9C4C5DD30F6807E5CAA0686C21363E4C /* TGSpreadsheetWriter */ = {
-			isa = PBXGroup;
-			children = (
-				3BD2BCEDFB78A820E986BC125AB99112 /* Common.h */,
-				55EB30039FA973FA56CBC419DE912DC7 /* SSZipArchive.h */,
-				F12D867DADEF9CF1B5E8F866B13DFF9B /* TGSpreadsheetWriter.h */,
-				3530DBF75398985B0150C5517334CD82 /* TGSpreadsheetWriter.m */,
-				05A29D9811FE50FC553EE8380C12A459 /* ZipArchive.h */,
-				AA9EAB656A53E3220431CE36DEB9683C /* Support Files */,
-			);
-			path = TGSpreadsheetWriter;
-			sourceTree = "<group>";
-		};
-		AA9EAB656A53E3220431CE36DEB9683C /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				673F8575BD473AF5AF685151CDCC192A /* Info.plist */,
-				3CC1D2825DD2D70DFC5C97B33482B657 /* TGSpreadsheetWriter.modulemap */,
-				8A26F9EF39256FD631BD62725E2402F7 /* TGSpreadsheetWriter.xcconfig */,
-				1C39AF29E5B53613D57105A4F510B0CD /* TGSpreadsheetWriter-dummy.m */,
-				1073FCE14723DD4CBB3C65F83CBF7FDF /* TGSpreadsheetWriter-prefix.pch */,
-				5F35DD12E0FAF85C747FB80152808849 /* TGSpreadsheetWriter-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/TGSpreadsheetWriter";
-			sourceTree = "<group>";
-		};
-		B15FBB607E84631F78CA08362B96CCFC /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				52DFB13C140C3580E039585DE95F297C /* Info.plist */,
-				40D1A523009273CD0AC912C47B7371A7 /* RealmConverter.modulemap */,
-				330511F3C7FE8CB73C875F331FB890D2 /* RealmConverter.xcconfig */,
-				FEC311E12DB84B8600A60E9FBA3799E0 /* RealmConverter-dummy.m */,
-				57095DD99474AD41DE3EEB4BE6F2D34E /* RealmConverter-prefix.pch */,
-				1EFED74A2EBBF8322E32677C9304BE56 /* RealmConverter-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/RealmConverter";
-			sourceTree = "<group>";
-		};
-		B7B80995527643776607AFFA75B91E24 /* Targets Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				75D98FF52E597A11900E131B6C4E1ADA /* Pods */,
-			);
-			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		DA9DB603212261629EE155B9D9953AEB /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				27DB5238F29570F7A603A75A91C32A54 /* CSwiftV.modulemap */,
-				82EF335C7BBCC60AEE64B430F4B9DF08 /* CSwiftV.xcconfig */,
-				DBE7F0C00830063060771EF7F00929D9 /* CSwiftV-dummy.m */,
-				1B394ACA1CE40F9DFC609B41FAA13E77 /* CSwiftV-prefix.pch */,
-				4E95F14A837F5530701D153685999E18 /* CSwiftV-umbrella.h */,
-				5C5DAF1B2F9D5EF96A9DDD60D0BB5BDC /* Info.plist */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/CSwiftV";
-			sourceTree = "<group>";
-		};
-		E8004BC3C383BE4026064214ABE245DD /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				12189A8DE8928260ECB0D0A3B97ED120 /* librealm-macosx.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		F3184C7D15E1C607B7B9D298339FEA2C /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				9C1E65AD80D079676A8F578109A642BC /* Info.plist */,
-				7DCBCBCB4B46B50367FA4493659182A3 /* SSZipArchive.modulemap */,
-				C8CC732936FA19529773DD3C751FFF2C /* SSZipArchive.xcconfig */,
-				B53D6206CA911D031F8053FC6636C7B1 /* SSZipArchive-dummy.m */,
-				AC4DB82A899509932498571314464BF1 /* SSZipArchive-prefix.pch */,
-				44A1469F401CF6008E8A2F3F60BC10BD /* SSZipArchive-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/SSZipArchive";
-			sourceTree = "<group>";
-		};
-		F5263B7FB0B4EF6A2110479832023FF8 /* SSZipArchive */ = {
-			isa = PBXGroup;
-			children = (
-				372D1E999518B8EE3D71FC3340D164A5 /* aes.h */,
-				716C4A29792DD68A1977222812EEF84D /* aes_via_ace.h */,
-				31081229799E9933D1976C60F2B8AE47 /* aescrypt.c */,
-				A8429AF4EF3E7FBCBE758A1200B23AE7 /* aeskey.c */,
-				2F441B555B2179F592E1CBA38663A808 /* aesopt.h */,
-				E22CE0498E06FD67D741E59D96E720A5 /* aestab.c */,
-				2F99C81EE3FD403B46B3F5D39C6B71D0 /* aestab.h */,
-				AA353BA701BC4981916B046E80579AFF /* brg_endian.h */,
-				EE34A6272512B232D721068FFE5A4D78 /* brg_types.h */,
-				54C6E0D9A39100A1B977F6AA98B6B498 /* Common.h */,
-				B4231AE1512289C8EA19666DD531F5B4 /* crypt.h */,
-				8B7EFFBC7FFCD4E65241A123E257CF7F /* entropy.c */,
-				89F0037B1208F4778B38B0CFF68348A7 /* entropy.h */,
-				FD49C997C594336277C7D44719D71E59 /* fileenc.c */,
-				05C969245C1B62E7985DEA4377653C72 /* fileenc.h */,
-				B8C4745957C099E9682B5181B1928187 /* hmac.c */,
-				2E68AE67BA0144854548E9637BE351FF /* hmac.h */,
-				35D92536BDC8AB8DEBA3A5613FC1BFFE /* ioapi.c */,
-				1D5BD286B05E51E6578C46A92D09BFC3 /* ioapi.h */,
-				3198887C97EACA777370AE6F188AF829 /* mztools.c */,
-				DE7AD83A17E01FB317130543AB9C44A6 /* mztools.h */,
-				86961DC4D50C3885E3F4A6B9039F2554 /* prng.c */,
-				4135B47426BBD4B027107FDD7DEFB3FB /* prng.h */,
-				06C5909E9BA9F11BC60281FCB528DDC7 /* pwd2key.c */,
-				AAE0D156249D94D4B7EA6573E78BECF5 /* pwd2key.h */,
-				C7DE9DCC709D99E2D78137CE68DA06EB /* sha1.c */,
-				7C6E2396FEF3F056166688C4BFD133CE /* sha1.h */,
-				7CF4D42A8F0D4F169E76D4E90E5C74C0 /* SSZipArchive.h */,
-				AFFAACC04CCAFAC7EF65AE188FFE14F6 /* SSZipArchive.m */,
-				70153F79B788A90BC4A9E3679583D60D /* unzip.c */,
-				F4E4D5458A3957A50C451BDD460A8146 /* unzip.h */,
-				FD499AC05B2273EEBB6CCEACDFB0D19A /* zip.c */,
-				3F7A768A0AD58A0C9F06AA6725EF8BDA /* zip.h */,
-				4B67266F7743232CEEA01857DEFCDC88 /* ZipArchive.h */,
-				F3184C7D15E1C607B7B9D298339FEA2C /* Support Files */,
-			);
-			path = SSZipArchive;
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXHeadersBuildPhase section */
-		0B8A9B8E14DFE9738C956468F7529231 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				158F8B831CCE64F91B39867CEEF47BF6 /* RealmConverter-umbrella.h in Headers */,
-				1E8B84BB47AB9083CE26251F95C8A7EE /* RealmConverter.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		32A208C34A4180490C67EDE664A2881D /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E704B906C21A38A983C00338833CFC7D /* Common.h in Headers */,
-				9E3042C037127666D3EC4870E35931F1 /* SSZipArchive.h in Headers */,
-				4E13713123BFFC907929C327E0D257D6 /* TGSpreadsheetWriter-umbrella.h in Headers */,
-				B28738B7DBEFB9D43FC99EF9818A6916 /* TGSpreadsheetWriter.h in Headers */,
-				7973B04F5D5599AEE7AC1C4E569DBC3D /* ZipArchive.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3A71C16CE157664F75F922991BA623FF /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A877F61198EF32BBAF3625076D9467D2 /* CSwiftV-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8AFC9DE3DA336CB21A2CD59C9B55922C /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D478998D346D9B7B148CCA1D90F73C62 /* Pods-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		91E668A10ED64B9B8A379425DED52829 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				21E000387A093C76D06321BF3BC9E425 /* PathKit-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A4B31E88AF7B67FD8EB4CB9D9E049F9A /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A72F6E679B47FA5BD09F2A9515288036 /* Realm.h in Headers */,
-				794ADD6313E9489BEC5E61A3457BC749 /* RLMAccessor.h in Headers */,
-				357D4F9B5F22AEB1F51AC790B0DE05C9 /* RLMArray.h in Headers */,
-				F26D7088043EDB28FC0D9C7ACEB6AC57 /* RLMArray_Private.h in Headers */,
-				B46FF231A9ED26AC96F3200492562CEC /* RLMCollection.h in Headers */,
-				25601A4F933B0288BA887045FAD4DB8A /* RLMConstants.h in Headers */,
-				3B0EE4ACCD03BBF2440A3693C074066C /* RLMDefines.h in Headers */,
-				AFF0DE37AF5F2ACAF91FB1D3D2DE329B /* RLMListBase.h in Headers */,
-				57CDBDC59BAED9EACDBECDCA5129FD7B /* RLMMigration.h in Headers */,
-				E29C0C24B7ADE76C71CCCEAC37FB4D19 /* RLMMigration_Private.h in Headers */,
-				3FC698B87150A428B273817AA134E9A5 /* RLMObject.h in Headers */,
-				14E8241278CA6C4ED286431E1BDCF9F2 /* RLMObject_Private.h in Headers */,
-				5B0A178E457A92024A18B74C29DD577C /* RLMObjectBase.h in Headers */,
-				95E6F9493F288E78458063FDA63ED930 /* RLMObjectBase_Dynamic.h in Headers */,
-				ACD8B8D4E93FBEB126BE3970FB377C17 /* RLMObjectSchema.h in Headers */,
-				3E7DDF75C64B7C507AF21ED0B97FA016 /* RLMObjectSchema_Private.h in Headers */,
-				F7435CF4F860EB2FC48BF128CB315A71 /* RLMObjectStore.h in Headers */,
-				C5BEA4C7CAC26163DFE867E0510006E7 /* RLMOptionalBase.h in Headers */,
-				1055889BAFAFD6054D7B61D9614CFC8E /* RLMPlatform.h in Headers */,
-				EA9AFA5D4BDF826B46132B8949545DD0 /* RLMProperty.h in Headers */,
-				78886685330CBFF0AFA0004658A5B4C5 /* RLMProperty_Private.h in Headers */,
-				855857FDF0A68C81EE20F8AFF89A998D /* RLMRealm.h in Headers */,
-				4ADAC9B7313F63B34197CA1F4A9E9C72 /* RLMRealm_Dynamic.h in Headers */,
-				9BD3D7793D7ED32F397541EB7A03ADAF /* RLMRealm_Private.h in Headers */,
-				B453E7A00408F4A77F033EDBD665E0ED /* RLMRealmConfiguration.h in Headers */,
-				50743BC1BE695769AC87A79B2D7F0D82 /* RLMRealmConfiguration_Private.h in Headers */,
-				D85E6244F76B7F8B12D4D391494C549E /* RLMResults.h in Headers */,
-				DC2E40164119E256D7CD886FE068C029 /* RLMResults_Private.h in Headers */,
-				F3FB5656F92619F47C6C5F3967907E13 /* RLMSchema.h in Headers */,
-				446866786867E9531A8AF2C25EED58D7 /* RLMSchema_Private.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A4DD38ED53EACDC80805C488A95210BA /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				09D4AA5011C7C94D70BCEEDD2DD935DF /* aes.h in Headers */,
-				CF4AD6AAD96373B95789F35D8E9D3785 /* aes_via_ace.h in Headers */,
-				D2FB1939848665F80BA9A114A3F79A8D /* aesopt.h in Headers */,
-				EB301B35774250D9DAF20A1BAFAC6914 /* aestab.h in Headers */,
-				D0B5097631EF99C0653439E1100F94E1 /* brg_endian.h in Headers */,
-				2282975F057A6767A8F330DC75192839 /* brg_types.h in Headers */,
-				E68BB55BC804EA907D8B5534ECCB03EB /* Common.h in Headers */,
-				10E29DDE9550025C74EA23C7E4CEF0F7 /* crypt.h in Headers */,
-				970D6045BECE13C47427CE89CDF56132 /* entropy.h in Headers */,
-				511F4A56904027806B5D5027A81ABB02 /* fileenc.h in Headers */,
-				3B6D4BAA76130B9A44305448F6A766BC /* hmac.h in Headers */,
-				6315AC8453D02A3FD59F9F71F364EA46 /* ioapi.h in Headers */,
-				B934A7BE0B67E9AB2143755F3388AC62 /* mztools.h in Headers */,
-				B5CC27E512BE35B3C19918582A3F1FD6 /* prng.h in Headers */,
-				F5A9E0302889F8E71A9B4C9F42484862 /* pwd2key.h in Headers */,
-				2EBD35649FB2E40FF0EEB5E150F57A0B /* sha1.h in Headers */,
-				AA867865E78E83FEA0E3998A8CE7EAAC /* SSZipArchive-umbrella.h in Headers */,
-				ACC6BDC6C06EB57F55D1AFC39749FD6D /* SSZipArchive.h in Headers */,
-				A2FD0A3B9B6479962E5C7B9BCD2B2EEA /* unzip.h in Headers */,
-				314AF406EAE652723D243081FFC5B55D /* zip.h in Headers */,
-				E2CC6849183CBD5E289DEA7828844947 /* ZipArchive.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EE29625675B175C13FB812E90C9F4025 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B80B0212901845EC122FCFCAF660DB1D /* AppSandboxFileAccess-umbrella.h in Headers */,
-				9448EEA86EEF2C88F0678F62B00BB0D1 /* AppSandboxFileAccess.h in Headers */,
-				0A47C7CA19CBD3E41CCD34CA089058D4 /* AppSandboxFileAccessOpenSavePanelDelegate.h in Headers */,
-				18A26B02BF9CEAF6AAA809AB342B5307 /* AppSandboxFileAccessPersist.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
-/* Begin PBXNativeTarget section */
-		0431D34712EA2D1E2771AA4D24AB3848 /* AppSandboxFileAccess */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 0FFE355635AC7E82B767D8FBF28D06E4 /* Build configuration list for PBXNativeTarget "AppSandboxFileAccess" */;
-			buildPhases = (
-				81393CC8ED1B52BAB3969C9D2157A593 /* Sources */,
-				88E202801384BBC86FDF42C356851E19 /* Frameworks */,
-				EE29625675B175C13FB812E90C9F4025 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = AppSandboxFileAccess;
-			productName = AppSandboxFileAccess;
-			productReference = 3B89A9461C52CD895C30943D4FF68AF9 /* AppSandboxFileAccess.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		0644799C31F10982A95C7FE6959F12BC /* Pods */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 33C1A029AE294CBFE2ADB589CFA8B916 /* Build configuration list for PBXNativeTarget "Pods" */;
-			buildPhases = (
-				F747F3DE19CA8FAEC9200499DDC99123 /* Sources */,
-				8E431233EAF533E1266BDF234908FE0D /* Frameworks */,
-				8AFC9DE3DA336CB21A2CD59C9B55922C /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				2AEFBA533BBA6517B162B9E82E461297 /* PBXTargetDependency */,
-				14A6F0F0057AB89B150B8A82BC13E7ED /* PBXTargetDependency */,
-				1B845341D2C04C92608DE8C3DB462BD6 /* PBXTargetDependency */,
-				C45BDFFB213CA83E3C74F7C87A0ABDD2 /* PBXTargetDependency */,
-				62DA93B3E522FD3C3F8A01627E2B0101 /* PBXTargetDependency */,
-				FE8DCA83B5CB285A4648176190034C00 /* PBXTargetDependency */,
-				E8ACF4880ADBCEE4708B9C01F80E5529 /* PBXTargetDependency */,
-			);
-			name = Pods;
-			productName = Pods;
-			productReference = 1E7BE00AFFDBDF6D840E2C8662F2BE42 /* Pods.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		0DFDC22D11F2D25D7BC65BA79C0C8FC9 /* SSZipArchive */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 6B6206BEBE50FE9886C8A9552FE3D11F /* Build configuration list for PBXNativeTarget "SSZipArchive" */;
-			buildPhases = (
-				39BE4B0D56D66D89021B19AEC9CC41C1 /* Sources */,
-				F2F5C77F6B8A82BE8F99A87FC3F189A7 /* Frameworks */,
-				A4DD38ED53EACDC80805C488A95210BA /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = SSZipArchive;
-			productName = SSZipArchive;
-			productReference = 9C322452B27A96368ACC916DB4EACE9D /* SSZipArchive.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		1C77996166FA926760F5CA781567DE18 /* TGSpreadsheetWriter */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8359C320A933C3944CBD1168CF20BDAD /* Build configuration list for PBXNativeTarget "TGSpreadsheetWriter" */;
-			buildPhases = (
-				C9CC55C4090A94AA1201659BA0C984AC /* Sources */,
-				5A32B536D41A7FF3766372F2865CBCF5 /* Frameworks */,
-				32A208C34A4180490C67EDE664A2881D /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				61704E6B6AC06835B215F7A79BF75744 /* PBXTargetDependency */,
-			);
-			name = TGSpreadsheetWriter;
-			productName = TGSpreadsheetWriter;
-			productReference = 34784815C02C831E3E00AF383632BC0E /* TGSpreadsheetWriter.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		A1E90C16CA7394ABAE6952B4887A7B81 /* RealmConverter */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 292BD8561A4227D74CE3A2DF1D05982E /* Build configuration list for PBXNativeTarget "RealmConverter" */;
-			buildPhases = (
-				171FADCEA90F391D40CA8776AF062C75 /* Sources */,
-				A1F85F7C52B80C457B84DCE87858EF1D /* Frameworks */,
-				0B8A9B8E14DFE9738C956468F7529231 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				C2A28F6F733D91ED94FC1F57AF8F4CA5 /* PBXTargetDependency */,
-				4C8CAF8A978D57B8BE208E8D5C3E2B6B /* PBXTargetDependency */,
-				62C959111EA36C35E395743533B36D13 /* PBXTargetDependency */,
-				7FF4D278CDAE2B74A777F0EA935C4A4E /* PBXTargetDependency */,
-			);
-			name = RealmConverter;
-			productName = RealmConverter;
-			productReference = 9E563B38E40DB43E6C8718B0C2BE9E2A /* RealmConverter.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		C9289771C9E400167D4D291E44982A06 /* CSwiftV */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 5C1BD6FAFE8954E49C824D5580F07BD7 /* Build configuration list for PBXNativeTarget "CSwiftV" */;
-			buildPhases = (
-				0FE1818D5B2E830251E4C81F395EA7AA /* Sources */,
-				8621E5C1CB20FA11CB771D77FB7B3AD2 /* Frameworks */,
-				3A71C16CE157664F75F922991BA623FF /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = CSwiftV;
-			productName = CSwiftV;
-			productReference = 8A293A690C61C7D33120456C1774581A /* CSwiftV.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		D0CD4B404F898BAC414372B461A667BF /* Realm */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F168664D938992F047DA4455117ACE52 /* Build configuration list for PBXNativeTarget "Realm" */;
-			buildPhases = (
-				3B11CBFD65D8885258193DF1B63B1F80 /* Sources */,
-				EAE26F5FFCA07C906946B3B3354CD3F3 /* Frameworks */,
-				A4B31E88AF7B67FD8EB4CB9D9E049F9A /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Realm;
-			productName = Realm;
-			productReference = 9E8AD47E2D34FE19688243E5F1328F63 /* Realm.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		F8DBBC6BB5AD1EBD4E9C618B36F18963 /* PathKit */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DBAA40395ABA7E82959ACE18C59290F5 /* Build configuration list for PBXNativeTarget "PathKit" */;
-			buildPhases = (
-				23795EC4A07A1F30584DA72FCC4C0DF2 /* Sources */,
-				FDE4BD31022A5A84F0CA297BF78DC225 /* Frameworks */,
-				91E668A10ED64B9B8A379425DED52829 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = PathKit;
-			productName = PathKit;
-			productReference = 550A6586B95D3032173E6F1A20C6F049 /* PathKit.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
-			};
-			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-			);
-			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
-			productRefGroup = 4D9F3C0F8F127C1F302BA2C94EBD2AC6 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				0431D34712EA2D1E2771AA4D24AB3848 /* AppSandboxFileAccess */,
-				C9289771C9E400167D4D291E44982A06 /* CSwiftV */,
-				F8DBBC6BB5AD1EBD4E9C618B36F18963 /* PathKit */,
-				0644799C31F10982A95C7FE6959F12BC /* Pods */,
-				D0CD4B404F898BAC414372B461A667BF /* Realm */,
-				A1E90C16CA7394ABAE6952B4887A7B81 /* RealmConverter */,
-				0DFDC22D11F2D25D7BC65BA79C0C8FC9 /* SSZipArchive */,
-				1C77996166FA926760F5CA781567DE18 /* TGSpreadsheetWriter */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXSourcesBuildPhase section */
-		0FE1818D5B2E830251E4C81F395EA7AA /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				15A2F91F6D730434DFA8020C30BFE6AF /* CSwiftV-dummy.m in Sources */,
-				BA055B534BD93E1154E785ED24765C0D /* CSwiftV.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		171FADCEA90F391D40CA8776AF062C75 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				7255CE045B5B76EA81FCBF9EE90E66CC /* CSVDataExporter.swift in Sources */,
-				CC0E23DC1A89303BD763AF75D5CFEC85 /* CSVDataImporter.swift in Sources */,
-				60FFAFC5F767C92C68EB6A8F1D7F3EE3 /* DataExporter.swift in Sources */,
-				26DDB79D8ABBFEB95FEC26066757C496 /* DataImporter.swift in Sources */,
-				07F70FB9AA910A28D5288F38B34AB36D /* Encoding.swift in Sources */,
-				7090784F4AC1E6E82F80899C759347E2 /* ImportObjectSchema.swift in Sources */,
-				21D5C26A2BD3B0DC4FA654BF4180E86D /* ImportSchema.swift in Sources */,
-				873894328ED6A3681E0BBE84F33F9156 /* ImportSchemaGenerator.swift in Sources */,
-				52034685912B207EF4207E28EDEC4318 /* RealmConverter-dummy.m in Sources */,
-				EB9A01C742FE18F233430751C19EAE7B /* String+CamelCase.swift in Sources */,
-				999AC8D622FC0F2C1073826143685189 /* XLSXDataImporter.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		23795EC4A07A1F30584DA72FCC4C0DF2 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DCE6244F4798467314F0547A1598949D /* PathKit-dummy.m in Sources */,
-				790DA773FCBB81AD7A9ADF0B7F86C66A /* PathKit.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		39BE4B0D56D66D89021B19AEC9CC41C1 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2D57B36C8CC1632E4C1667D8C845630B /* aescrypt.c in Sources */,
-				DE210B0FAF0C41A54011E0736706C9AD /* aeskey.c in Sources */,
-				000ECEEFBA9B290EBF4D0B5E3789D37C /* aestab.c in Sources */,
-				6540D3CEB07A63EE8CB4DE046333219F /* entropy.c in Sources */,
-				1C2ABCB19989B2949F3E5B578A16C3B5 /* fileenc.c in Sources */,
-				17C390119E3AD0EBBB7477FD919A80AA /* hmac.c in Sources */,
-				6248F8F3D5A83C7F0EE043E23A953A5E /* ioapi.c in Sources */,
-				C0346FDF36155B025E7FE4B13227A243 /* mztools.c in Sources */,
-				CF2E9B7C1D862BB5667287B02F918198 /* prng.c in Sources */,
-				062DCE379C878985044360451F35E744 /* pwd2key.c in Sources */,
-				44C8CAAF531F32F5FC732AF78C17E28F /* sha1.c in Sources */,
-				E3542F21C12A8F20472B801BE260DDEF /* SSZipArchive-dummy.m in Sources */,
-				AED3600F6B88D062A901C0D2EBCC7752 /* SSZipArchive.m in Sources */,
-				9F183C647578D111DF61F06BBFF6143E /* unzip.c in Sources */,
-				BA7B2DACB5CF0834E1B165A0BED8854E /* zip.c in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3B11CBFD65D8885258193DF1B63B1F80 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				71758734DCAB13CB42491204952F215A /* async_query.cpp in Sources */,
-				86A6FDB24833F6E99807B9EDD3CB9ED4 /* cached_realm.cpp in Sources */,
-				514DAA1755FE0C7F1F98E79CBA8F33D4 /* external_commit_helper.cpp in Sources */,
-				3C13BE699CCAB51C4D31542233FC5755 /* index_set.cpp in Sources */,
-				8D9A038653F6DD0202AC51BED1C1A389 /* object_schema.cpp in Sources */,
-				56B31612F88D2271F385321D48D85612 /* object_store.cpp in Sources */,
-				2BC251710F9BCC30D0A27631D64CD789 /* Realm-dummy.m in Sources */,
-				90A17AC7A1011EB1D7EF60F985DBA0EF /* realm_coordinator.cpp in Sources */,
-				E594D6C2C03BE35386B70A6233F7CE33 /* results.cpp in Sources */,
-				861D5388547D81FC79FE89944449FBA2 /* RLMAccessor.mm in Sources */,
-				5E98C43341C9E0E0241302AFCC22404F /* RLMAnalytics.mm in Sources */,
-				B1C6632902573DE8DC763DF17736FC45 /* RLMArray.mm in Sources */,
-				5E6507B634AA2F13EE0EB877310A0C6B /* RLMArrayLinkView.mm in Sources */,
-				AF90AFF3C49DC4F5BFDDE81C8CF33C94 /* RLMConstants.m in Sources */,
-				9FF09B4D2038571D92013130C5067096 /* RLMListBase.mm in Sources */,
-				8A66293323CD45D2852C2D42D612D53D /* RLMMigration.mm in Sources */,
-				9CD712A5BA98A0C0C46E0A468B7A7C48 /* RLMObject.mm in Sources */,
-				F331322EACCE12E8E004AAA7CB2A8AC4 /* RLMObjectBase.mm in Sources */,
-				5BA359F4E8AD40493C48EA6A19F60CAF /* RLMObjectSchema.mm in Sources */,
-				A0D4017D654BA0F228DA44BCE40EFA69 /* RLMObjectStore.mm in Sources */,
-				D79BCA99C1FC7A2B3224FBC676957F7A /* RLMObservation.mm in Sources */,
-				8AA5E9FFE41C8340BA3B262A2A0EA12E /* RLMOptionalBase.mm in Sources */,
-				775B9FF071C51C2CB231169D9D0DDD8C /* RLMPredicateUtil.mm in Sources */,
-				139D64691FB0421C1AAF22EAD4D010B9 /* RLMProperty.mm in Sources */,
-				A4BFF8BBF8068EA5B85C3BEF335FDE11 /* RLMQueryUtil.mm in Sources */,
-				F7616315433905E44350B61CF1F3AF2B /* RLMRealm.mm in Sources */,
-				A3AB553C1F23F2F94FBCC183AF919508 /* RLMRealmConfiguration.mm in Sources */,
-				F0C0D57BB3AD8DD7721499CDA0B333A2 /* RLMRealmUtil.mm in Sources */,
-				225120EAF6EB8A24B02186AD56F19CF4 /* RLMResults.mm in Sources */,
-				C7D6BADCE9C5D01C8F55865D07158BD0 /* RLMSchema.mm in Sources */,
-				250D71DE54AEC07D94A28427C528A526 /* RLMSwiftSupport.m in Sources */,
-				CF71512BD773F9F94F95DF5A26013BC2 /* RLMUpdateChecker.mm in Sources */,
-				D5284C3580D66E6D035869B2A11DFB8B /* RLMUtil.mm in Sources */,
-				3ABC47F83F9119370B9EFB7F039FB5A1 /* schema.cpp in Sources */,
-				118555F3BDF23E1DE2A8A5F6E4317672 /* shared_realm.cpp in Sources */,
-				0516C976D88B0DEE23481F946CB6C6CE /* transact_log_handler.cpp in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		81393CC8ED1B52BAB3969C9D2157A593 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				EE7A46055D614EB4E266A6A8678BA94B /* AppSandboxFileAccess-dummy.m in Sources */,
-				4CBA3872A464CD39846C56038EBD8FCF /* AppSandboxFileAccess.m in Sources */,
-				6A4B50C549836B1559B971C3E826819D /* AppSandboxFileAccessOpenSavePanelDelegate.m in Sources */,
-				272CE2753DF442F09C9C7735893CD9A2 /* AppSandboxFileAccessPersist.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		C9CC55C4090A94AA1201659BA0C984AC /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2E428116A40B080D11E84AB8F6BCD7A5 /* TGSpreadsheetWriter-dummy.m in Sources */,
-				D822F3F5388DA53393ED93B9350C5702 /* TGSpreadsheetWriter.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F747F3DE19CA8FAEC9200499DDC99123 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				30B394005B43898E7D40C54F8CD2D80E /* Pods-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		14A6F0F0057AB89B150B8A82BC13E7ED /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = CSwiftV;
-			target = C9289771C9E400167D4D291E44982A06 /* CSwiftV */;
-			targetProxy = 0A832F515C62BDDA906C29AA023E898A /* PBXContainerItemProxy */;
-		};
-		1B845341D2C04C92608DE8C3DB462BD6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = PathKit;
-			target = F8DBBC6BB5AD1EBD4E9C618B36F18963 /* PathKit */;
-			targetProxy = 60CF1ADE211B8283EC097D1297B87E76 /* PBXContainerItemProxy */;
-		};
-		2AEFBA533BBA6517B162B9E82E461297 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AppSandboxFileAccess;
-			target = 0431D34712EA2D1E2771AA4D24AB3848 /* AppSandboxFileAccess */;
-			targetProxy = 29D8F8F3CDC97676551A1F67B07520E8 /* PBXContainerItemProxy */;
-		};
-		4C8CAF8A978D57B8BE208E8D5C3E2B6B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = PathKit;
-			target = F8DBBC6BB5AD1EBD4E9C618B36F18963 /* PathKit */;
-			targetProxy = BFA77BE3AF51AA10E6ED8EB65E333A31 /* PBXContainerItemProxy */;
-		};
-		61704E6B6AC06835B215F7A79BF75744 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SSZipArchive;
-			target = 0DFDC22D11F2D25D7BC65BA79C0C8FC9 /* SSZipArchive */;
-			targetProxy = A5B7328037649BCBEE8E293C6030C4BC /* PBXContainerItemProxy */;
-		};
-		62C959111EA36C35E395743533B36D13 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Realm;
-			target = D0CD4B404F898BAC414372B461A667BF /* Realm */;
-			targetProxy = 243F8EFF55CCACD27364AAAAE26DB1B5 /* PBXContainerItemProxy */;
-		};
-		62DA93B3E522FD3C3F8A01627E2B0101 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = RealmConverter;
-			target = A1E90C16CA7394ABAE6952B4887A7B81 /* RealmConverter */;
-			targetProxy = 1A73584D0AF5ED5D935679953F3A399D /* PBXContainerItemProxy */;
-		};
-		7FF4D278CDAE2B74A777F0EA935C4A4E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = TGSpreadsheetWriter;
-			target = 1C77996166FA926760F5CA781567DE18 /* TGSpreadsheetWriter */;
-			targetProxy = 85F6C4400DDA8CC1C2E65D599B81C8DD /* PBXContainerItemProxy */;
-		};
-		C2A28F6F733D91ED94FC1F57AF8F4CA5 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = CSwiftV;
-			target = C9289771C9E400167D4D291E44982A06 /* CSwiftV */;
-			targetProxy = C6362637BD272EAA7517AF82AFD5AB2B /* PBXContainerItemProxy */;
-		};
-		C45BDFFB213CA83E3C74F7C87A0ABDD2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Realm;
-			target = D0CD4B404F898BAC414372B461A667BF /* Realm */;
-			targetProxy = CFBF68BD3B74877080C303E00FC0C496 /* PBXContainerItemProxy */;
-		};
-		E8ACF4880ADBCEE4708B9C01F80E5529 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = TGSpreadsheetWriter;
-			target = 1C77996166FA926760F5CA781567DE18 /* TGSpreadsheetWriter */;
-			targetProxy = 65FD849FE888931EF384B7D5C09AB7A5 /* PBXContainerItemProxy */;
-		};
-		FE8DCA83B5CB285A4648176190034C00 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SSZipArchive;
-			target = 0DFDC22D11F2D25D7BC65BA79C0C8FC9 /* SSZipArchive */;
-			targetProxy = B47485278D763CEF443861F6FBA92B65 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin XCBuildConfiguration section */
-		20E4607B2D71E90A04B79A0835E3E606 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C8CC732936FA19529773DD3C751FFF2C /* SSZipArchive.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/SSZipArchive/SSZipArchive-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/SSZipArchive/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/SSZipArchive/SSZipArchive.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = SSZipArchive;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		27F4333DEE211DCEC4A586A6D606ADB9 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 330511F3C7FE8CB73C875F331FB890D2 /* RealmConverter.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/RealmConverter/RealmConverter-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/RealmConverter/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/RealmConverter/RealmConverter.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = RealmConverter;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		4525D6614CAB2AA2025AB88C6C32B576 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8A26F9EF39256FD631BD62725E2402F7 /* TGSpreadsheetWriter.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/TGSpreadsheetWriter/TGSpreadsheetWriter-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/TGSpreadsheetWriter/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/TGSpreadsheetWriter/TGSpreadsheetWriter.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = TGSpreadsheetWriter;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		4AA1CBEE9B262E33B392AF95F56ADC2C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AC5F2A74AE518C6C97ED0BDB2B27333 /* Realm.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/Realm/Realm-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Realm/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/Realm/Realm.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Realm;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		52D4ECB745D1C035F94BD060EE7F6605 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				ONLY_ACTIVE_ARCH = YES;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-			};
-			name = Debug;
-		};
-		78272D0C17D45E3934365F70754D433D /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = DA312349A49333542E6F4B36B329960E /* Pods.release.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "Target Support Files/Pods/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/Pods/Pods.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		78485DE33545AACBF2F167AF981576E3 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 82EF335C7BBCC60AEE64B430F4B9DF08 /* CSwiftV.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/CSwiftV/CSwiftV-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/CSwiftV/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/CSwiftV/CSwiftV.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = CSwiftV;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		78DC08D48DBEF104EB2C2CCAC2272EB7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 08F6E0C44E12D9CA8DF2DBC5866DE5B5 /* PathKit.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/PathKit/PathKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/PathKit/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/PathKit/PathKit.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = PathKit;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		7C4744535A1C98E97117A9850C8C8658 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 977577C045EDA9D9D1F46E2598D19FC7 /* Pods.debug.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "Target Support Files/Pods/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/Pods/Pods.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = Pods;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		A070F153A04DD66F4E492261894B37FF /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		B172BF9C9A298326CB45BFA2D3FBD2DA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8A26F9EF39256FD631BD62725E2402F7 /* TGSpreadsheetWriter.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/TGSpreadsheetWriter/TGSpreadsheetWriter-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/TGSpreadsheetWriter/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/TGSpreadsheetWriter/TGSpreadsheetWriter.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = TGSpreadsheetWriter;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		B90C49FBE7F9F113C5E6D0F4023F1E63 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 08F6E0C44E12D9CA8DF2DBC5866DE5B5 /* PathKit.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/PathKit/PathKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/PathKit/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/PathKit/PathKit.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = PathKit;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		C394E7920190475674D9AD11760C5165 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AC5F2A74AE518C6C97ED0BDB2B27333 /* Realm.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/Realm/Realm-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Realm/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/Realm/Realm.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Realm;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		CEEBF007167B3D3AC4331C4FF75C020B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0CBF82A7A39169D30B8A20E7229E7A18 /* AppSandboxFileAccess.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/AppSandboxFileAccess/AppSandboxFileAccess-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/AppSandboxFileAccess/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/AppSandboxFileAccess/AppSandboxFileAccess.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = AppSandboxFileAccess;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		DC317A257FA26430E2747B489CD6B09C /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C8CC732936FA19529773DD3C751FFF2C /* SSZipArchive.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/SSZipArchive/SSZipArchive-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/SSZipArchive/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/SSZipArchive/SSZipArchive.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = SSZipArchive;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		E8F0FAF691DC0C086DC7853A35838DA2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 330511F3C7FE8CB73C875F331FB890D2 /* RealmConverter.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/RealmConverter/RealmConverter-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/RealmConverter/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/RealmConverter/RealmConverter.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = RealmConverter;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		EF2985BF643FB0330E23155C2A8CB698 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 82EF335C7BBCC60AEE64B430F4B9DF08 /* CSwiftV.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/CSwiftV/CSwiftV-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/CSwiftV/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/CSwiftV/CSwiftV.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = CSwiftV;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		F14FE9B738330F029E174A12203B83CB /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0CBF82A7A39169D30B8A20E7229E7A18 /* AppSandboxFileAccess.xcconfig */;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_PREFIX_HEADER = "Target Support Files/AppSandboxFileAccess/AppSandboxFileAccess-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/AppSandboxFileAccess/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MODULEMAP_FILE = "Target Support Files/AppSandboxFileAccess/AppSandboxFileAccess.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = AppSandboxFileAccess;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		0FFE355635AC7E82B767D8FBF28D06E4 /* Build configuration list for PBXNativeTarget "AppSandboxFileAccess" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				CEEBF007167B3D3AC4331C4FF75C020B /* Debug */,
-				F14FE9B738330F029E174A12203B83CB /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		292BD8561A4227D74CE3A2DF1D05982E /* Build configuration list for PBXNativeTarget "RealmConverter" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				27F4333DEE211DCEC4A586A6D606ADB9 /* Debug */,
-				E8F0FAF691DC0C086DC7853A35838DA2 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				52D4ECB745D1C035F94BD060EE7F6605 /* Debug */,
-				A070F153A04DD66F4E492261894B37FF /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		33C1A029AE294CBFE2ADB589CFA8B916 /* Build configuration list for PBXNativeTarget "Pods" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				7C4744535A1C98E97117A9850C8C8658 /* Debug */,
-				78272D0C17D45E3934365F70754D433D /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		5C1BD6FAFE8954E49C824D5580F07BD7 /* Build configuration list for PBXNativeTarget "CSwiftV" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				EF2985BF643FB0330E23155C2A8CB698 /* Debug */,
-				78485DE33545AACBF2F167AF981576E3 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		6B6206BEBE50FE9886C8A9552FE3D11F /* Build configuration list for PBXNativeTarget "SSZipArchive" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				20E4607B2D71E90A04B79A0835E3E606 /* Debug */,
-				DC317A257FA26430E2747B489CD6B09C /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		8359C320A933C3944CBD1168CF20BDAD /* Build configuration list for PBXNativeTarget "TGSpreadsheetWriter" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				B172BF9C9A298326CB45BFA2D3FBD2DA /* Debug */,
-				4525D6614CAB2AA2025AB88C6C32B576 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		DBAA40395ABA7E82959ACE18C59290F5 /* Build configuration list for PBXNativeTarget "PathKit" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				78DC08D48DBEF104EB2C2CCAC2272EB7 /* Debug */,
-				B90C49FBE7F9F113C5E6D0F4023F1E63 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		F168664D938992F047DA4455117ACE52 /* Build configuration list for PBXNativeTarget "Realm" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				4AA1CBEE9B262E33B392AF95F56ADC2C /* Debug */,
-				C394E7920190475674D9AD11760C5165 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>000ECEEFBA9B290EBF4D0B5E3789D37C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E22CE0498E06FD67D741E59D96E720A5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>0126D3CD668280339023A015BBF887A5</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>72176F811D85F6AE2E7BF90CBD601644</string>
+				<string>DA9DB603212261629EE155B9D9953AEB</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>CSwiftV</string>
+			<key>path</key>
+			<string>CSwiftV</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>03310AFFA2A8A25C1E0E64E97063707A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C1B856FA1794963765B6B11447040661</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>03424E15C2D5A576CD2A2ED39E6C6E9B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>index_set.cpp</string>
+			<key>path</key>
+			<string>Realm/ObjectStore/index_set.cpp</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0431D34712EA2D1E2771AA4D24AB3848</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>0FFE355635AC7E82B767D8FBF28D06E4</string>
+			<key>buildPhases</key>
+			<array>
+				<string>81393CC8ED1B52BAB3969C9D2157A593</string>
+				<string>88E202801384BBC86FDF42C356851E19</string>
+				<string>EE29625675B175C13FB812E90C9F4025</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>AppSandboxFileAccess</string>
+			<key>productName</key>
+			<string>AppSandboxFileAccess</string>
+			<key>productReference</key>
+			<string>3B89A9461C52CD895C30943D4FF68AF9</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>04B964E9C58BE2B1D8E41942B9D7242E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMProperty_Private.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMProperty_Private.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>05A29D9811FE50FC553EE8380C12A459</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>ZipArchive.h</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter/ZipArchive.framework/Versions/A/Headers/ZipArchive.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>05C969245C1B62E7985DEA4377653C72</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>fileenc.h</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/fileenc.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>062DCE379C878985044360451F35E744</key>
+		<dict>
+			<key>fileRef</key>
+			<string>06C5909E9BA9F11BC60281FCB528DDC7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>0644799C31F10982A95C7FE6959F12BC</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>33C1A029AE294CBFE2ADB589CFA8B916</string>
+			<key>buildPhases</key>
+			<array>
+				<string>F747F3DE19CA8FAEC9200499DDC99123</string>
+				<string>8E431233EAF533E1266BDF234908FE0D</string>
+				<string>8AFC9DE3DA336CB21A2CD59C9B55922C</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>2AEFBA533BBA6517B162B9E82E461297</string>
+				<string>14A6F0F0057AB89B150B8A82BC13E7ED</string>
+				<string>1B845341D2C04C92608DE8C3DB462BD6</string>
+				<string>C45BDFFB213CA83E3C74F7C87A0ABDD2</string>
+				<string>62DA93B3E522FD3C3F8A01627E2B0101</string>
+				<string>FE8DCA83B5CB285A4648176190034C00</string>
+				<string>E8ACF4880ADBCEE4708B9C01F80E5529</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>productName</key>
+			<string>Pods</string>
+			<key>productReference</key>
+			<string>1E7BE00AFFDBDF6D840E2C8662F2BE42</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>06C5909E9BA9F11BC60281FCB528DDC7</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>pwd2key.c</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/pwd2key.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>07894E49BED389CD196F901827EC6A19</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMArray.mm</string>
+			<key>path</key>
+			<string>Realm/RLMArray.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>07F70FB9AA910A28D5288F38B34AB36D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B1ECB794421C4581658AE60E13BEA337</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>08F6E0C44E12D9CA8DF2DBC5866DE5B5</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>PathKit.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>09D4AA5011C7C94D70BCEEDD2DD935DF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>372D1E999518B8EE3D71FC3340D164A5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>0A47C7CA19CBD3E41CCD34CA089058D4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A5A585A14DEE51BD017795B9A5BFF371</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>0A832F515C62BDDA906C29AA023E898A</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>C9289771C9E400167D4D291E44982A06</string>
+			<key>remoteInfo</key>
+			<string>CSwiftV</string>
+		</dict>
+		<key>0B8A9B8E14DFE9738C956468F7529231</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>158F8B831CCE64F91B39867CEEF47BF6</string>
+				<string>1E8B84BB47AB9083CE26251F95C8A7EE</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>0BB450E5051F002DCD6DF65F4C4F147F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMRealm.mm</string>
+			<key>path</key>
+			<string>Realm/RLMRealm.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0C32BDA03399CEE008733EC4E942F5AB</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMAccessor.mm</string>
+			<key>path</key>
+			<string>Realm/RLMAccessor.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0CBF82A7A39169D30B8A20E7229E7A18</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0DFDC22D11F2D25D7BC65BA79C0C8FC9</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>6B6206BEBE50FE9886C8A9552FE3D11F</string>
+			<key>buildPhases</key>
+			<array>
+				<string>39BE4B0D56D66D89021B19AEC9CC41C1</string>
+				<string>F2F5C77F6B8A82BE8F99A87FC3F189A7</string>
+				<string>A4DD38ED53EACDC80805C488A95210BA</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>SSZipArchive</string>
+			<key>productName</key>
+			<string>SSZipArchive</string>
+			<key>productReference</key>
+			<string>9C322452B27A96368ACC916DB4EACE9D</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>0FE1818D5B2E830251E4C81F395EA7AA</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>15A2F91F6D730434DFA8020C30BFE6AF</string>
+				<string>BA055B534BD93E1154E785ED24765C0D</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>0FFE355635AC7E82B767D8FBF28D06E4</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>CEEBF007167B3D3AC4331C4FF75C020B</string>
+				<string>F14FE9B738330F029E174A12203B83CB</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>1020DC3FBB8E70DE1DAE17C97E85333E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMMigration.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMMigration.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1055889BAFAFD6054D7B61D9614CFC8E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>AB0FBCDE4D353AAC203D8510CD88849D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>1073FCE14723DD4CBB3C65F83CBF7FDF</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>10E29DDE9550025C74EA23C7E4CEF0F7</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B4231AE1512289C8EA19666DD531F5B4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>111C0E4A52077D19B9B5AE075F686880</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMAnalytics.mm</string>
+			<key>path</key>
+			<string>Realm/RLMAnalytics.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>12189A8DE8928260ECB0D0A3B97ED120</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>archive.ar</string>
+			<key>name</key>
+			<string>librealm-macosx.a</string>
+			<key>path</key>
+			<string>core/librealm-macosx.a</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>127C0D709EA76419CDD3F71CB1C11EAD</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>ImportSchema.swift</string>
+			<key>path</key>
+			<string>RealmConverter/Schema/ImportSchema.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>12D309788220A2E65B26D1EB9DAFBD4C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>FC70D2C69CFEAFBE595CF4B7A74BF947</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>14A6F0F0057AB89B150B8A82BC13E7ED</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>CSwiftV</string>
+			<key>target</key>
+			<string>C9289771C9E400167D4D291E44982A06</string>
+			<key>targetProxy</key>
+			<string>0A832F515C62BDDA906C29AA023E898A</string>
+		</dict>
+		<key>14E8241278CA6C4ED286431E1BDCF9F2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>5F10FF47841D4AAA329F613B6EC48340</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Private</string>
+				</array>
+			</dict>
+		</dict>
+		<key>14EFD886E4361BC20FB65E7089303D8B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMListBase.mm</string>
+			<key>path</key>
+			<string>Realm/RLMListBase.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>158F8B831CCE64F91B39867CEEF47BF6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1EFED74A2EBBF8322E32677C9304BE56</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>15A2F91F6D730434DFA8020C30BFE6AF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DBE7F0C00830063060771EF7F00929D9</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1613577FE131ADE567FBD6DF6F3FDA70</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMRealm.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMRealm.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>16669CB94E13E0E2A56357B5A990584E</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>94DF76D80C35A421434CADCC0FA98700</string>
+				<string>0126D3CD668280339023A015BBF887A5</string>
+				<string>4F948398FE4B95997689935C8B532ADA</string>
+				<string>4E6EC8A776A5FB4C53472CEB067DB690</string>
+				<string>3A43C812EB4F68034C7C671B29CD5982</string>
+				<string>F5263B7FB0B4EF6A2110479832023FF8</string>
+				<string>9C4C5DD30F6807E5CAA0686C21363E4C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>171FADCEA90F391D40CA8776AF062C75</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>7255CE045B5B76EA81FCBF9EE90E66CC</string>
+				<string>CC0E23DC1A89303BD763AF75D5CFEC85</string>
+				<string>60FFAFC5F767C92C68EB6A8F1D7F3EE3</string>
+				<string>26DDB79D8ABBFEB95FEC26066757C496</string>
+				<string>07F70FB9AA910A28D5288F38B34AB36D</string>
+				<string>7090784F4AC1E6E82F80899C759347E2</string>
+				<string>21D5C26A2BD3B0DC4FA654BF4180E86D</string>
+				<string>873894328ED6A3681E0BBE84F33F9156</string>
+				<string>52034685912B207EF4207E28EDEC4318</string>
+				<string>EB9A01C742FE18F233430751C19EAE7B</string>
+				<string>999AC8D622FC0F2C1073826143685189</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>17650893B51708A441A7FF79DEF2DAD0</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>17C390119E3AD0EBBB7477FD919A80AA</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8C4745957C099E9682B5181B1928187</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>18A26B02BF9CEAF6AAA809AB342B5307</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A042AC754D95496EB6398473225A7078</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>1A73584D0AF5ED5D935679953F3A399D</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>A1E90C16CA7394ABAE6952B4887A7B81</string>
+			<key>remoteInfo</key>
+			<string>RealmConverter</string>
+		</dict>
+		<key>1AE19F1FFD4B623527C27BF05D2BF31D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>schema.cpp</string>
+			<key>path</key>
+			<string>Realm/ObjectStore/schema.cpp</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1B394ACA1CE40F9DFC609B41FAA13E77</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>CSwiftV-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1B845341D2C04C92608DE8C3DB462BD6</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>PathKit</string>
+			<key>target</key>
+			<string>F8DBBC6BB5AD1EBD4E9C618B36F18963</string>
+			<key>targetProxy</key>
+			<string>60CF1ADE211B8283EC097D1297B87E76</string>
+		</dict>
+		<key>1BA86B34A7ADF7C1260A7466874DD7D5</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMUtil.mm</string>
+			<key>path</key>
+			<string>Realm/RLMUtil.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1C2ABCB19989B2949F3E5B578A16C3B5</key>
+		<dict>
+			<key>fileRef</key>
+			<string>FD49C997C594336277C7D44719D71E59</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>1C39AF29E5B53613D57105A4F510B0CD</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1C77996166FA926760F5CA781567DE18</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>8359C320A933C3944CBD1168CF20BDAD</string>
+			<key>buildPhases</key>
+			<array>
+				<string>C9CC55C4090A94AA1201659BA0C984AC</string>
+				<string>5A32B536D41A7FF3766372F2865CBCF5</string>
+				<string>32A208C34A4180490C67EDE664A2881D</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>61704E6B6AC06835B215F7A79BF75744</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>TGSpreadsheetWriter</string>
+			<key>productName</key>
+			<string>TGSpreadsheetWriter</string>
+			<key>productReference</key>
+			<string>34784815C02C831E3E00AF383632BC0E</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>1CAF6C55A82A67E4B3D1003CFB3369A9</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMProperty.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMProperty.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1CE2B9AFFC43023F6FF64F38F3DBBECE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>ImportSchemaGenerator.swift</string>
+			<key>path</key>
+			<string>RealmConverter/Schema/ImportSchemaGenerator.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1D5BD286B05E51E6578C46A92D09BFC3</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>ioapi.h</string>
+			<key>path</key>
+			<string>SSZipArchive/minizip/ioapi.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1DDDA9921A7144720EB431B6CAF58571</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>SSZipArchive.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>1E0615CF56088C501D87706816F66F05</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMRealmConfiguration.mm</string>
+			<key>path</key>
+			<string>Realm/RLMRealmConfiguration.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1E7BE00AFFDBDF6D840E2C8662F2BE42</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Pods.framework</string>
+			<key>path</key>
+			<string>Pods.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>1E8B84BB47AB9083CE26251F95C8A7EE</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C9200253A8AE36C3AB6DEFE3AC62C075</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>1EFED74A2EBBF8322E32677C9304BE56</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>RealmConverter-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>20E4607B2D71E90A04B79A0835E3E606</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>C8CC732936FA19529773DD3C751FFF2C</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/SSZipArchive/SSZipArchive-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/SSZipArchive/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/SSZipArchive/SSZipArchive.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>SSZipArchive</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>21B59C1A4A3C949D88977978CDDCD0DF</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMMigration_Private.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMMigration_Private.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>21D5C26A2BD3B0DC4FA654BF4180E86D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>127C0D709EA76419CDD3F71CB1C11EAD</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>21E000387A093C76D06321BF3BC9E425</key>
+		<dict>
+			<key>fileRef</key>
+			<string>250D3DADF320E007F9BF93AB25F8A037</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>2282975F057A6767A8F330DC75192839</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EE34A6272512B232D721068FFE5A4D78</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>23795EC4A07A1F30584DA72FCC4C0DF2</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DCE6244F4798467314F0547A1598949D</string>
+				<string>790DA773FCBB81AD7A9ADF0B7F86C66A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>243F8EFF55CCACD27364AAAAE26DB1B5</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>D0CD4B404F898BAC414372B461A667BF</string>
+			<key>remoteInfo</key>
+			<string>Realm</string>
+		</dict>
+		<key>24BB64FDE8E4F4C58C66185E955469AF</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMRealmConfiguration_Private.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMRealmConfiguration_Private.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>250D3DADF320E007F9BF93AB25F8A037</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>PathKit-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>25601A4F933B0288BA887045FAD4DB8A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>43103CF0EDC745ED1FABF936B4334F8D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>26DDB79D8ABBFEB95FEC26066757C496</key>
+		<dict>
+			<key>fileRef</key>
+			<string>71C39ECE6DDDADF5E1A4F45352B339E4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27036DAD4BB60AF60BE6BC2BE2791BD7</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>CSVDataExporter.swift</string>
+			<key>path</key>
+			<string>RealmConverter/Exporter/CSVDataExporter.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>272CE2753DF442F09C9C7735893CD9A2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A1DA738A84039E33733961E6B3E317D9</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>27DB5238F29570F7A603A75A91C32A54</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>CSwiftV.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27F4333DEE211DCEC4A586A6D606ADB9</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>330511F3C7FE8CB73C875F331FB890D2</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/RealmConverter/RealmConverter-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/RealmConverter/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/RealmConverter/RealmConverter.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>RealmConverter</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>2870052BD274EAC4879A7FB53B98BA71</key>
+		<dict>
+			<key>fileRef</key>
+			<string>95420313339AF991DDC48B242C068AB0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>292BD8561A4227D74CE3A2DF1D05982E</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>27F4333DEE211DCEC4A586A6D606ADB9</string>
+				<string>E8F0FAF691DC0C086DC7853A35838DA2</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>2960CB11EBD6ADC737E702878E70B37C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>29D8F8F3CDC97676551A1F67B07520E8</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>0431D34712EA2D1E2771AA4D24AB3848</string>
+			<key>remoteInfo</key>
+			<string>AppSandboxFileAccess</string>
+		</dict>
+		<key>2AEFBA533BBA6517B162B9E82E461297</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>AppSandboxFileAccess</string>
+			<key>target</key>
+			<string>0431D34712EA2D1E2771AA4D24AB3848</string>
+			<key>targetProxy</key>
+			<string>29D8F8F3CDC97676551A1F67B07520E8</string>
+		</dict>
+		<key>2BC251710F9BCC30D0A27631D64CD789</key>
+		<dict>
+			<key>fileRef</key>
+			<string>F49D90E43BEB2AA8A737BADDCBAA3087</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>2BCC458FDD5F692BBB2BFC64BB5701FC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Pods-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2D57B36C8CC1632E4C1667D8C845630B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>31081229799E9933D1976C60F2B8AE47</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>2D8E8EC45A3A1A1D94AE762CB5028504</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>52D4ECB745D1C035F94BD060EE7F6605</string>
+				<string>A070F153A04DD66F4E492261894B37FF</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>2E428116A40B080D11E84AB8F6BCD7A5</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1C39AF29E5B53613D57105A4F510B0CD</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>2E677ED832818D55044C7D5701265114</key>
+		<dict>
+			<key>fileRef</key>
+			<string>07894E49BED389CD196F901827EC6A19</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>2E68AE67BA0144854548E9637BE351FF</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>hmac.h</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/hmac.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2E85BD6029B5A4E38247B8133FA951E9</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>PathKit.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>2EBD35649FB2E40FF0EEB5E150F57A0B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>7C6E2396FEF3F056166688C4BFD133CE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>2F441B555B2179F592E1CBA38663A808</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>aesopt.h</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/aesopt.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2F99C81EE3FD403B46B3F5D39C6B71D0</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>aestab.h</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/aestab.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>30B394005B43898E7D40C54F8CD2D80E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>894E5DA93A9F359521A89826BE6DA777</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>31081229799E9933D1976C60F2B8AE47</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>aescrypt.c</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/aescrypt.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>314AF406EAE652723D243081FFC5B55D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3F7A768A0AD58A0C9F06AA6725EF8BDA</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>3198887C97EACA777370AE6F188AF829</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>mztools.c</string>
+			<key>path</key>
+			<string>SSZipArchive/minizip/mztools.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>32A208C34A4180490C67EDE664A2881D</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>E704B906C21A38A983C00338833CFC7D</string>
+				<string>9E3042C037127666D3EC4870E35931F1</string>
+				<string>4E13713123BFFC907929C327E0D257D6</string>
+				<string>B28738B7DBEFB9D43FC99EF9818A6916</string>
+				<string>7973B04F5D5599AEE7AC1C4E569DBC3D</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>32DD6F1207FF69A12F0E6A8109B639A9</key>
+		<dict>
+			<key>fileRef</key>
+			<string>111C0E4A52077D19B9B5AE075F686880</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>330511F3C7FE8CB73C875F331FB890D2</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>RealmConverter.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>33C1A029AE294CBFE2ADB589CFA8B916</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>7C4744535A1C98E97117A9850C8C8658</string>
+				<string>78272D0C17D45E3934365F70754D433D</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>34784815C02C831E3E00AF383632BC0E</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>TGSpreadsheetWriter.framework</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>3530DBF75398985B0150C5517334CD82</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>TGSpreadsheetWriter.m</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter/TGSpreadsheetWriter.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>355392CC6F82DB3D00CEF56FC4B53633</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>external_commit_helper.cpp</string>
+			<key>path</key>
+			<string>Realm/ObjectStore/impl/apple/external_commit_helper.cpp</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>357D4F9B5F22AEB1F51AC790B0DE05C9</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A68A5681C548CA29D8B6854F430B46FA</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>35D92536BDC8AB8DEBA3A5613FC1BFFE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>ioapi.c</string>
+			<key>path</key>
+			<string>SSZipArchive/minizip/ioapi.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>372D1E999518B8EE3D71FC3340D164A5</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>aes.h</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/aes.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>37EDB653332F73BE50868CAE1799508D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMObjectBase.mm</string>
+			<key>path</key>
+			<string>Realm/RLMObjectBase.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3803D882518A91345A998713852DBFE9</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMListBase.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMListBase.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3824AA76DE171EAD9ACF0C6BA55B45D3</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMObjectSchema.mm</string>
+			<key>path</key>
+			<string>Realm/RLMObjectSchema.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3935171316CB2D6D538FF51A2757F251</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>2960CB11EBD6ADC737E702878E70B37C</string>
+				<string>0CBF82A7A39169D30B8A20E7229E7A18</string>
+				<string>17650893B51708A441A7FF79DEF2DAD0</string>
+				<string>FA2B9B51D5095FB9B92784C1A76782D5</string>
+				<string>B1FCEDB643FAF9E812BD22FC813BA25A</string>
+				<string>B71ABEDF6A3C3AA1CC4AC880C7BC8A86</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/AppSandboxFileAccess</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>39BE4B0D56D66D89021B19AEC9CC41C1</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>2D57B36C8CC1632E4C1667D8C845630B</string>
+				<string>DE210B0FAF0C41A54011E0736706C9AD</string>
+				<string>000ECEEFBA9B290EBF4D0B5E3789D37C</string>
+				<string>6540D3CEB07A63EE8CB4DE046333219F</string>
+				<string>1C2ABCB19989B2949F3E5B578A16C3B5</string>
+				<string>17C390119E3AD0EBBB7477FD919A80AA</string>
+				<string>6248F8F3D5A83C7F0EE043E23A953A5E</string>
+				<string>C0346FDF36155B025E7FE4B13227A243</string>
+				<string>CF2E9B7C1D862BB5667287B02F918198</string>
+				<string>062DCE379C878985044360451F35E744</string>
+				<string>44C8CAAF531F32F5FC732AF78C17E28F</string>
+				<string>E3542F21C12A8F20472B801BE260DDEF</string>
+				<string>AED3600F6B88D062A901C0D2EBCC7752</string>
+				<string>9F183C647578D111DF61F06BBFF6143E</string>
+				<string>BA7B2DACB5CF0834E1B165A0BED8854E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>3A43C812EB4F68034C7C671B29CD5982</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27036DAD4BB60AF60BE6BC2BE2791BD7</string>
+				<string>B21FF966A642F7DF524A2FFD92271B27</string>
+				<string>C0ED6A24D351EA7318641F59FA8CC831</string>
+				<string>71C39ECE6DDDADF5E1A4F45352B339E4</string>
+				<string>B1ECB794421C4581658AE60E13BEA337</string>
+				<string>79764CC7086366871B7D1D089EE9CEDE</string>
+				<string>127C0D709EA76419CDD3F71CB1C11EAD</string>
+				<string>1CE2B9AFFC43023F6FF64F38F3DBBECE</string>
+				<string>C9200253A8AE36C3AB6DEFE3AC62C075</string>
+				<string>DBB05F4BA4BADCFFC489810FA229A121</string>
+				<string>CAD5C8EFBD82FCA7F4C711DDCE626676</string>
+				<string>B15FBB607E84631F78CA08362B96CCFC</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>RealmConverter</string>
+			<key>path</key>
+			<string>RealmConverter</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3A71C16CE157664F75F922991BA623FF</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>A877F61198EF32BBAF3625076D9467D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>3B0EE4ACCD03BBF2440A3693C074066C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A0496BBB3CF3A07D65946972DDCB906C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>3B11CBFD65D8885258193DF1B63B1F80</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>7869E015BDB76CB63858F08AD3D15F4C</string>
+				<string>E5B093DC83F76FEFCEFED39FB79A8DCC</string>
+				<string>42958869A4B891F0CD5CB7EF7B4B5617</string>
+				<string>5D653ABACBEFD00539F9904190D93C5C</string>
+				<string>3FAB3BB3C18FF8DFD010F2C0FD7C0EE6</string>
+				<string>3F31EF45267EBF383BD23EC9804D5B51</string>
+				<string>2BC251710F9BCC30D0A27631D64CD789</string>
+				<string>9876CDDD5871A75252FFE47200F82C84</string>
+				<string>BD5F283AA572A97F02CE3C171E17AB24</string>
+				<string>810633542B4AC62F20696E9EE3B86672</string>
+				<string>32DD6F1207FF69A12F0E6A8109B639A9</string>
+				<string>2E677ED832818D55044C7D5701265114</string>
+				<string>928BA533A262F37108A7171552B79562</string>
+				<string>D1F93CEB80733991DDF579E93A392F60</string>
+				<string>DA5ED5C1DFC5BC211B5C49E01B1360C1</string>
+				<string>EA6036ECAB6EEBF91FEF6A6D49ABB6FF</string>
+				<string>A4F7C8A2EA6831936F500EDD988D5685</string>
+				<string>BC10585B1807C756CDB33F02A382A260</string>
+				<string>CA2671F2B70D86BCD5122CC8E8FE286B</string>
+				<string>D69800DBB23F2122BC215A5EE42B9FAD</string>
+				<string>03310AFFA2A8A25C1E0E64E97063707A</string>
+				<string>12D309788220A2E65B26D1EB9DAFBD4C</string>
+				<string>DC831F65978C85088F18DA16200C453C</string>
+				<string>3F940848F323FC0AAEC72EBAF7C1A382</string>
+				<string>9F93B849606BA632862F620388F1CD71</string>
+				<string>6D23EE9EAC58727BFBF059495450DDE2</string>
+				<string>9A9B0D7B92D1264ADC6F9EDAEF1FDCAE</string>
+				<string>46E242BBD7865B785CCEF597380843B0</string>
+				<string>B11AE06127E3E224E76102D875C6CA29</string>
+				<string>5C69B863437AF5B354BF1F0A2E5FA182</string>
+				<string>47B40EA7ACAAF880B12936D21E64A8F2</string>
+				<string>D6D9453A1A3FF2248860EB52453B2474</string>
+				<string>649E47136F319F3127796EAF1CB5BED2</string>
+				<string>99AE3C32FB99FCA39E72BF9F82496DEE</string>
+				<string>2870052BD274EAC4879A7FB53B98BA71</string>
+				<string>48BBCBAFCE648861B3F8FF80272A04BA</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>3B6D4BAA76130B9A44305448F6A766BC</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2E68AE67BA0144854548E9637BE351FF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>3B89A9461C52CD895C30943D4FF68AF9</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>AppSandboxFileAccess.framework</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>3BD2BCEDFB78A820E986BC125AB99112</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>Common.h</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter/ZipArchive.framework/Versions/A/Headers/Common.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3CC1D2825DD2D70DFC5C97B33482B657</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3E7DDF75C64B7C507AF21ED0B97FA016</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C4B83AB3AD2940C100050FC255571F5B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Private</string>
+				</array>
+			</dict>
+		</dict>
+		<key>3F31EF45267EBF383BD23EC9804D5B51</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8803880F9B2DEDE45EBF1B8ECE83A699</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>3F7A768A0AD58A0C9F06AA6725EF8BDA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>zip.h</string>
+			<key>path</key>
+			<string>SSZipArchive/minizip/zip.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3F940848F323FC0AAEC72EBAF7C1A382</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A19421B9966A85C3EAC8DDC4FBCFCAF9</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>3FAB3BB3C18FF8DFD010F2C0FD7C0EE6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9A5A17348B4D0E60ABAA4D040EA8DFED</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>3FC698B87150A428B273817AA134E9A5</key>
+		<dict>
+			<key>fileRef</key>
+			<string>7F457A03F9AAC050288B25C55486010D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>40D1A523009273CD0AC912C47B7371A7</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>RealmConverter.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4135B47426BBD4B027107FDD7DEFB3FB</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>prng.h</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/prng.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>42958869A4B891F0CD5CB7EF7B4B5617</key>
+		<dict>
+			<key>fileRef</key>
+			<string>355392CC6F82DB3D00CEF56FC4B53633</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>43103CF0EDC745ED1FABF936B4334F8D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMConstants.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMConstants.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>446866786867E9531A8AF2C25EED58D7</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DCE2B1A050EB5CEEA7ADDCD3C05F54E0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Private</string>
+				</array>
+			</dict>
+		</dict>
+		<key>44A1469F401CF6008E8A2F3F60BC10BD</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>SSZipArchive-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>44C604182F0C5BD5AB1B9EF2BD4B7D22</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>PathKit.swift</string>
+			<key>path</key>
+			<string>Sources/PathKit.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>44C8CAAF531F32F5FC732AF78C17E28F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C7DE9DCC709D99E2D78137CE68DA06EB</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>4525D6614CAB2AA2025AB88C6C32B576</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>8A26F9EF39256FD631BD62725E2402F7</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/TGSpreadsheetWriter/TGSpreadsheetWriter-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/TGSpreadsheetWriter/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/TGSpreadsheetWriter/TGSpreadsheetWriter.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>TGSpreadsheetWriter</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>46E242BBD7865B785CCEF597380843B0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4F76EFE18C9CC8BC88AE6DA1C782FE1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>47B40EA7ACAAF880B12936D21E64A8F2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4918C17F01E89C4D4A1EF222716F5C4C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>48BBCBAFCE648861B3F8FF80272A04BA</key>
+		<dict>
+			<key>fileRef</key>
+			<string>F52EC04D9DC0AE2842735C7D17BD3787</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>4918C17F01E89C4D4A1EF222716F5C4C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>RLMSwiftSupport.m</string>
+			<key>path</key>
+			<string>Realm/RLMSwiftSupport.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4AA1CBEE9B262E33B392AF95F56ADC2C</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>7AC5F2A74AE518C6C97ED0BDB2B27333</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Realm/Realm-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Realm/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Realm/Realm.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>Realm</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>4ADAC9B7313F63B34197CA1F4A9E9C72</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EDAA7BD525EAC1621E00BCBC3E8C1EC5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>4B1F27CAFD4C276D9D74B2A933F3CB45</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMResults.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMResults.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4B67266F7743232CEEA01857DEFCDC88</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>ZipArchive.h</string>
+			<key>path</key>
+			<string>SSZipArchive/ZipArchive.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4C8CAF8A978D57B8BE208E8D5C3E2B6B</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>PathKit</string>
+			<key>target</key>
+			<string>F8DBBC6BB5AD1EBD4E9C618B36F18963</string>
+			<key>targetProxy</key>
+			<string>BFA77BE3AF51AA10E6ED8EB65E333A31</string>
+		</dict>
+		<key>4CBA3872A464CD39846C56038EBD8FCF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A086A964EFA9C3A7879C3129B759FFCE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>4D9F3C0F8F127C1F302BA2C94EBD2AC6</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>3B89A9461C52CD895C30943D4FF68AF9</string>
+				<string>8A293A690C61C7D33120456C1774581A</string>
+				<string>550A6586B95D3032173E6F1A20C6F049</string>
+				<string>1E7BE00AFFDBDF6D840E2C8662F2BE42</string>
+				<string>9E8AD47E2D34FE19688243E5F1328F63</string>
+				<string>9E563B38E40DB43E6C8718B0C2BE9E2A</string>
+				<string>9C322452B27A96368ACC916DB4EACE9D</string>
+				<string>34784815C02C831E3E00AF383632BC0E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4E13713123BFFC907929C327E0D257D6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>5F35DD12E0FAF85C747FB80152808849</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>4E6EC8A776A5FB4C53472CEB067DB690</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>6B2A3090815002E3CB22D9C0833BB20D</string>
+				<string>54C8EB611A0A77E462591BD7970E7968</string>
+				<string>355392CC6F82DB3D00CEF56FC4B53633</string>
+				<string>03424E15C2D5A576CD2A2ED39E6C6E9B</string>
+				<string>9A5A17348B4D0E60ABAA4D040EA8DFED</string>
+				<string>8803880F9B2DEDE45EBF1B8ECE83A699</string>
+				<string>ED8762338AC853B059F0078B7BF54C74</string>
+				<string>B52762951A1DBC3E77A33ABD829FEE0D</string>
+				<string>594E74B6BCE69D8DD34926C7D82C9178</string>
+				<string>0C32BDA03399CEE008733EC4E942F5AB</string>
+				<string>111C0E4A52077D19B9B5AE075F686880</string>
+				<string>07894E49BED389CD196F901827EC6A19</string>
+				<string>C3C4E3105B0FA8266054F37B2AE56540</string>
+				<string>A02FB283C242F581628F1E1860C29BA3</string>
+				<string>BF080C07656878AAB4897C2BBFA46B13</string>
+				<string>3803D882518A91345A998713852DBFE9</string>
+				<string>14EFD886E4361BC20FB65E7089303D8B</string>
+				<string>D24235CDF995FC31A2897A5A7283FC5E</string>
+				<string>21B59C1A4A3C949D88977978CDDCD0DF</string>
+				<string>DAB7D91BBCF663D88A2F0482906EB695</string>
+				<string>5F10FF47841D4AAA329F613B6EC48340</string>
+				<string>37EDB653332F73BE50868CAE1799508D</string>
+				<string>3824AA76DE171EAD9ACF0C6BA55B45D3</string>
+				<string>C4B83AB3AD2940C100050FC255571F5B</string>
+				<string>68FF1B6FC0C6DE4F36B50D5E4E87AFF8</string>
+				<string>A3F3D3E4246FB153A3C238A0890D8C7A</string>
+				<string>C1B856FA1794963765B6B11447040661</string>
+				<string>9ABC69341A34F40BBD661AE423D06E3E</string>
+				<string>FC70D2C69CFEAFBE595CF4B7A74BF947</string>
+				<string>E84A16B2DD844599EC3037DA81D2038D</string>
+				<string>A19421B9966A85C3EAC8DDC4FBCFCAF9</string>
+				<string>04B964E9C58BE2B1D8E41942B9D7242E</string>
+				<string>DB255E01E754531C0F73C07C6ECAACC1</string>
+				<string>0BB450E5051F002DCD6DF65F4C4F147F</string>
+				<string>CBC0335B8B9B9D0BA1CC6AF6495929D9</string>
+				<string>1E0615CF56088C501D87706816F66F05</string>
+				<string>24BB64FDE8E4F4C58C66185E955469AF</string>
+				<string>4F76EFE18C9CC8BC88AE6DA1C782FE1C</string>
+				<string>DFA0C81489C637F0DA69EB1F54B6AEE5</string>
+				<string>C5504A46EA0B3A6D2FE2C3911CDFACA4</string>
+				<string>7210605A669DE89C7D8A5F4395EEAD7E</string>
+				<string>DCE2B1A050EB5CEEA7ADDCD3C05F54E0</string>
+				<string>4918C17F01E89C4D4A1EF222716F5C4C</string>
+				<string>5A24BC47325BB22483160927840DA2CC</string>
+				<string>1BA86B34A7ADF7C1260A7466874DD7D5</string>
+				<string>1AE19F1FFD4B623527C27BF05D2BF31D</string>
+				<string>95420313339AF991DDC48B242C068AB0</string>
+				<string>F52EC04D9DC0AE2842735C7D17BD3787</string>
+				<string>E8004BC3C383BE4026064214ABE245DD</string>
+				<string>9A88B67BA53DC06138354AE4AB06BBEC</string>
+				<string>7602C62CAAF32D05AEA4475DD82A9B27</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Realm</string>
+			<key>path</key>
+			<string>Realm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4E95F14A837F5530701D153685999E18</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>CSwiftV-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4F76EFE18C9CC8BC88AE6DA1C782FE1C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMRealmUtil.mm</string>
+			<key>path</key>
+			<string>Realm/RLMRealmUtil.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4F948398FE4B95997689935C8B532ADA</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>44C604182F0C5BD5AB1B9EF2BD4B7D22</string>
+				<string>976B681CB49490257B24B748167EE9F5</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>PathKit</string>
+			<key>path</key>
+			<string>PathKit</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4FC442CF7DD73E52ECFD60891097F2AE</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A2E224763DAA078EE22DC2EF01A9B1F6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>50743BC1BE695769AC87A79B2D7F0D82</key>
+		<dict>
+			<key>fileRef</key>
+			<string>24BB64FDE8E4F4C58C66185E955469AF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Private</string>
+				</array>
+			</dict>
+		</dict>
+		<key>511F4A56904027806B5D5027A81ABB02</key>
+		<dict>
+			<key>fileRef</key>
+			<string>05C969245C1B62E7985DEA4377653C72</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>52034685912B207EF4207E28EDEC4318</key>
+		<dict>
+			<key>fileRef</key>
+			<string>FEC311E12DB84B8600A60E9FBA3799E0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>52D4ECB745D1C035F94BD060EE7F6605</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>STRIP_INSTALLED_PRODUCT</key>
+				<string>NO</string>
+				<key>SYMROOT</key>
+				<string>${SRCROOT}/../build</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>52DFB13C140C3580E039585DE95F297C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>54C6E0D9A39100A1B977F6AA98B6B498</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>Common.h</string>
+			<key>path</key>
+			<string>SSZipArchive/Common.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>54C8EB611A0A77E462591BD7970E7968</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>cached_realm.cpp</string>
+			<key>path</key>
+			<string>Realm/ObjectStore/impl/apple/cached_realm.cpp</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>550A6586B95D3032173E6F1A20C6F049</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>PathKit.framework</string>
+			<key>path</key>
+			<string>PathKit.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>55EB30039FA973FA56CBC419DE912DC7</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SSZipArchive.h</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter/ZipArchive.framework/Versions/A/Headers/SSZipArchive.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>57095DD99474AD41DE3EEB4BE6F2D34E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>RealmConverter-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>571D4F3D11A96E570A814E7D4A3A17BE</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>A2E224763DAA078EE22DC2EF01A9B1F6</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>OS X</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>57CDBDC59BAED9EACDBECDCA5129FD7B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1020DC3FBB8E70DE1DAE17C97E85333E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>594E74B6BCE69D8DD34926C7D82C9178</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMAccessor.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMAccessor.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>59F03CA5F870A59A7DC4FE571FF85A80</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>Realm.h</string>
+			<key>path</key>
+			<string>include/Realm/Realm.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5A24BC47325BB22483160927840DA2CC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMUpdateChecker.mm</string>
+			<key>path</key>
+			<string>Realm/RLMUpdateChecker.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5A32B536D41A7FF3766372F2865CBCF5</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>EC4E64AD48AAF9E2943ACB390398369A</string>
+				<string>E1AC9B1FE18A1562F9378EC7DFAD8648</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>5B0A178E457A92024A18B74C29DD577C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B8AE37511CF793AD65D0B6411DE3C4D1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>5C1BD6FAFE8954E49C824D5580F07BD7</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>EF2985BF643FB0330E23155C2A8CB698</string>
+				<string>78485DE33545AACBF2F167AF981576E3</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>5C5DAF1B2F9D5EF96A9DDD60D0BB5BDC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5C69B863437AF5B354BF1F0A2E5FA182</key>
+		<dict>
+			<key>fileRef</key>
+			<string>7210605A669DE89C7D8A5F4395EEAD7E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>5D653ABACBEFD00539F9904190D93C5C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>03424E15C2D5A576CD2A2ED39E6C6E9B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>5D8256413F416A8B75806ABA3C35E42B</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>745CFE9844D5ADA3FA496AF4EA9A2391</string>
+				<string>2E85BD6029B5A4E38247B8133FA951E9</string>
+				<string>9C757FF507346A6EB9D2540C8E620D79</string>
+				<string>1DDDA9921A7144720EB431B6CAF58571</string>
+				<string>F42F2F73B04A3EC00CF51F753925309C</string>
+				<string>571D4F3D11A96E570A814E7D4A3A17BE</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5F10FF47841D4AAA329F613B6EC48340</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMObject_Private.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMObject_Private.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5F35DD12E0FAF85C747FB80152808849</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5F702A59D013D9F682E348CA76AEE172</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A2E224763DAA078EE22DC2EF01A9B1F6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>60CF1ADE211B8283EC097D1297B87E76</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>F8DBBC6BB5AD1EBD4E9C618B36F18963</string>
+			<key>remoteInfo</key>
+			<string>PathKit</string>
+		</dict>
+		<key>60FFAFC5F767C92C68EB6A8F1D7F3EE3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C0ED6A24D351EA7318641F59FA8CC831</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>61704E6B6AC06835B215F7A79BF75744</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>SSZipArchive</string>
+			<key>target</key>
+			<string>0DFDC22D11F2D25D7BC65BA79C0C8FC9</string>
+			<key>targetProxy</key>
+			<string>A5B7328037649BCBEE8E293C6030C4BC</string>
+		</dict>
+		<key>6248F8F3D5A83C7F0EE043E23A953A5E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>35D92536BDC8AB8DEBA3A5613FC1BFFE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>62C959111EA36C35E395743533B36D13</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Realm</string>
+			<key>target</key>
+			<string>D0CD4B404F898BAC414372B461A667BF</string>
+			<key>targetProxy</key>
+			<string>243F8EFF55CCACD27364AAAAE26DB1B5</string>
+		</dict>
+		<key>62DA93B3E522FD3C3F8A01627E2B0101</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>RealmConverter</string>
+			<key>target</key>
+			<string>A1E90C16CA7394ABAE6952B4887A7B81</string>
+			<key>targetProxy</key>
+			<string>1A73584D0AF5ED5D935679953F3A399D</string>
+		</dict>
+		<key>6315AC8453D02A3FD59F9F71F364EA46</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1D5BD286B05E51E6578C46A92D09BFC3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>649E47136F319F3127796EAF1CB5BED2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1BA86B34A7ADF7C1260A7466874DD7D5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>6540D3CEB07A63EE8CB4DE046333219F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8B7EFFBC7FFCD4E65241A123E257CF7F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>65FD849FE888931EF384B7D5C09AB7A5</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>1C77996166FA926760F5CA781567DE18</string>
+			<key>remoteInfo</key>
+			<string>TGSpreadsheetWriter</string>
+		</dict>
+		<key>67085DAA3DC8DFB79CA4AFB23B88ED03</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>673F8575BD473AF5AF685151CDCC192A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>68FF1B6FC0C6DE4F36B50D5E4E87AFF8</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMObjectStore.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMObjectStore.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6A4B50C549836B1559B971C3E826819D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A878C683463E5D95C28E7DF9A2068391</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>6B2A3090815002E3CB22D9C0833BB20D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>async_query.cpp</string>
+			<key>path</key>
+			<string>Realm/ObjectStore/impl/async_query.cpp</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6B6206BEBE50FE9886C8A9552FE3D11F</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>20E4607B2D71E90A04B79A0835E3E606</string>
+				<string>DC317A257FA26430E2747B489CD6B09C</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>6D23EE9EAC58727BFBF059495450DDE2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>0BB450E5051F002DCD6DF65F4C4F147F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>70153F79B788A90BC4A9E3679583D60D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>unzip.c</string>
+			<key>path</key>
+			<string>SSZipArchive/minizip/unzip.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7090784F4AC1E6E82F80899C759347E2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>79764CC7086366871B7D1D089EE9CEDE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>716C4A29792DD68A1977222812EEF84D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>aes_via_ace.h</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/aes_via_ace.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>71C39ECE6DDDADF5E1A4F45352B339E4</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>DataImporter.swift</string>
+			<key>path</key>
+			<string>RealmConverter/Importer/DataImporter.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7210605A669DE89C7D8A5F4395EEAD7E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMSchema.mm</string>
+			<key>path</key>
+			<string>Realm/RLMSchema.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>72176F811D85F6AE2E7BF90CBD601644</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>CSwiftV.swift</string>
+			<key>path</key>
+			<string>CSwiftV/CSwiftV.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7255CE045B5B76EA81FCBF9EE90E66CC</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27036DAD4BB60AF60BE6BC2BE2791BD7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>745CFE9844D5ADA3FA496AF4EA9A2391</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>CSwiftV.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>75D98FF52E597A11900E131B6C4E1ADA</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>E8446514FBAD26C0E18F24A5715AEF67</string>
+				<string>79A9DEDC89FE8336BF5FEDAAF75BF7FC</string>
+				<string>D0405803033A2A777B8E4DFA0C1800ED</string>
+				<string>87B213035BAC5F75386F62D3C75D2342</string>
+				<string>894E5DA93A9F359521A89826BE6DA777</string>
+				<string>E7F21354943D9F42A70697D5A5EF72E9</string>
+				<string>CBC0F7C552B739C909B650A0F42F7F38</string>
+				<string>2BCC458FDD5F692BBB2BFC64BB5701FC</string>
+				<string>977577C045EDA9D9D1F46E2598D19FC7</string>
+				<string>DA312349A49333542E6F4B36B329960E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>path</key>
+			<string>Target Support Files/Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7602C62CAAF32D05AEA4475DD82A9B27</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>67085DAA3DC8DFB79CA4AFB23B88ED03</string>
+				<string>963D87FDD08BED60C7AAD8238A147DD1</string>
+				<string>7AC5F2A74AE518C6C97ED0BDB2B27333</string>
+				<string>F49D90E43BEB2AA8A737BADDCBAA3087</string>
+				<string>7B946225F6DC665FBE058EB6B9C7A641</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/Realm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>78272D0C17D45E3934365F70754D433D</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>DA312349A49333542E6F4B36B329960E</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods/Pods.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>78485DE33545AACBF2F167AF981576E3</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>82EF335C7BBCC60AEE64B430F4B9DF08</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/CSwiftV/CSwiftV-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/CSwiftV/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/CSwiftV/CSwiftV.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>CSwiftV</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>7869E015BDB76CB63858F08AD3D15F4C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6B2A3090815002E3CB22D9C0833BB20D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>78886685330CBFF0AFA0004658A5B4C5</key>
+		<dict>
+			<key>fileRef</key>
+			<string>04B964E9C58BE2B1D8E41942B9D7242E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Private</string>
+				</array>
+			</dict>
+		</dict>
+		<key>78DC08D48DBEF104EB2C2CCAC2272EB7</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>08F6E0C44E12D9CA8DF2DBC5866DE5B5</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/PathKit/PathKit-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/PathKit/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/PathKit/PathKit.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>PathKit</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>790DA773FCBB81AD7A9ADF0B7F86C66A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>44C604182F0C5BD5AB1B9EF2BD4B7D22</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>794ADD6313E9489BEC5E61A3457BC749</key>
+		<dict>
+			<key>fileRef</key>
+			<string>594E74B6BCE69D8DD34926C7D82C9178</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Private</string>
+				</array>
+			</dict>
+		</dict>
+		<key>7973B04F5D5599AEE7AC1C4E569DBC3D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>05A29D9811FE50FC553EE8380C12A459</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>79764CC7086366871B7D1D089EE9CEDE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>ImportObjectSchema.swift</string>
+			<key>path</key>
+			<string>RealmConverter/Schema/ImportObjectSchema.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>79A9DEDC89FE8336BF5FEDAAF75BF7FC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Pods.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7AC5F2A74AE518C6C97ED0BDB2B27333</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Realm.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7B77BF0083B2A3FE0247DC63E8C16CA0</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMSchema.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMSchema.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7B946225F6DC665FBE058EB6B9C7A641</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Realm-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7C4744535A1C98E97117A9850C8C8658</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>977577C045EDA9D9D1F46E2598D19FC7</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Pods/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Pods/Pods.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>Pods</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>7C6E2396FEF3F056166688C4BFD133CE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>sha1.h</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/sha1.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7CF4D42A8F0D4F169E76D4E90E5C74C0</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SSZipArchive.h</string>
+			<key>path</key>
+			<string>SSZipArchive/SSZipArchive.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7DB346D0F39D3F0E887471402A8071AB</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BA6428E9F66FD5A23C0A2E06ED26CD2F</string>
+				<string>5D8256413F416A8B75806ABA3C35E42B</string>
+				<string>16669CB94E13E0E2A56357B5A990584E</string>
+				<string>4D9F3C0F8F127C1F302BA2C94EBD2AC6</string>
+				<string>B7B80995527643776607AFFA75B91E24</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7DCBCBCB4B46B50367FA4493659182A3</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>SSZipArchive.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7F457A03F9AAC050288B25C55486010D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMObject.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMObject.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7FF4D278CDAE2B74A777F0EA935C4A4E</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>TGSpreadsheetWriter</string>
+			<key>target</key>
+			<string>1C77996166FA926760F5CA781567DE18</string>
+			<key>targetProxy</key>
+			<string>85F6C4400DDA8CC1C2E65D599B81C8DD</string>
+		</dict>
+		<key>810633542B4AC62F20696E9EE3B86672</key>
+		<dict>
+			<key>fileRef</key>
+			<string>0C32BDA03399CEE008733EC4E942F5AB</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>81393CC8ED1B52BAB3969C9D2157A593</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>EE7A46055D614EB4E266A6A8678BA94B</string>
+				<string>4CBA3872A464CD39846C56038EBD8FCF</string>
+				<string>6A4B50C549836B1559B971C3E826819D</string>
+				<string>272CE2753DF442F09C9C7735893CD9A2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>82EF335C7BBCC60AEE64B430F4B9DF08</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>CSwiftV.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8359C320A933C3944CBD1168CF20BDAD</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>B172BF9C9A298326CB45BFA2D3FBD2DA</string>
+				<string>4525D6614CAB2AA2025AB88C6C32B576</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>839C6F803412E9E34416A049CB85BD85</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9C757FF507346A6EB9D2540C8E620D79</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>855857FDF0A68C81EE20F8AFF89A998D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1613577FE131ADE567FBD6DF6F3FDA70</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>85F6C4400DDA8CC1C2E65D599B81C8DD</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>1C77996166FA926760F5CA781567DE18</string>
+			<key>remoteInfo</key>
+			<string>TGSpreadsheetWriter</string>
+		</dict>
+		<key>8621E5C1CB20FA11CB771D77FB7B3AD2</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>4FC442CF7DD73E52ECFD60891097F2AE</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>86961DC4D50C3885E3F4A6B9039F2554</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>prng.c</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/prng.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>873894328ED6A3681E0BBE84F33F9156</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1CE2B9AFFC43023F6FF64F38F3DBBECE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>87B213035BAC5F75386F62D3C75D2342</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Pods-acknowledgements.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8803880F9B2DEDE45EBF1B8ECE83A699</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>object_store.cpp</string>
+			<key>path</key>
+			<string>Realm/ObjectStore/object_store.cpp</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>88E202801384BBC86FDF42C356851E19</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>C238473D12590CFD4363445513344DFB</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>894E5DA93A9F359521A89826BE6DA777</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Pods-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89D13F76001C05818D50C48B10052874</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A2E224763DAA078EE22DC2EF01A9B1F6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>89F0037B1208F4778B38B0CFF68348A7</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>entropy.h</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/entropy.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8A26F9EF39256FD631BD62725E2402F7</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8A293A690C61C7D33120456C1774581A</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>CSwiftV.framework</string>
+			<key>path</key>
+			<string>CSwiftV.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>8A4E5A63C89400E1B3EE4D720E49F86F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8AFC9DE3DA336CB21A2CD59C9B55922C</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>D478998D346D9B7B148CCA1D90F73C62</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>8B7EFFBC7FFCD4E65241A123E257CF7F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>entropy.c</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/entropy.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8E431233EAF533E1266BDF234908FE0D</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>5F702A59D013D9F682E348CA76AEE172</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>904335DE07D1D67885592BA72317EEAC</key>
+		<dict>
+			<key>fileRef</key>
+			<string>F42F2F73B04A3EC00CF51F753925309C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>91E668A10ED64B9B8A379425DED52829</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>21E000387A093C76D06321BF3BC9E425</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>928BA533A262F37108A7171552B79562</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A02FB283C242F581628F1E1860C29BA3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>92C77F228BD83616B71F63BD4DB0E24A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A2E224763DAA078EE22DC2EF01A9B1F6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9448EEA86EEF2C88F0678F62B00BB0D1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>D5165BCE41EC813689C4C6F4F29CC3C6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>94DF76D80C35A421434CADCC0FA98700</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>D5165BCE41EC813689C4C6F4F29CC3C6</string>
+				<string>A086A964EFA9C3A7879C3129B759FFCE</string>
+				<string>A5A585A14DEE51BD017795B9A5BFF371</string>
+				<string>A878C683463E5D95C28E7DF9A2068391</string>
+				<string>A042AC754D95496EB6398473225A7078</string>
+				<string>A1DA738A84039E33733961E6B3E317D9</string>
+				<string>3935171316CB2D6D538FF51A2757F251</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>AppSandboxFileAccess</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>95420313339AF991DDC48B242C068AB0</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>shared_realm.cpp</string>
+			<key>path</key>
+			<string>Realm/ObjectStore/shared_realm.cpp</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>95E6F9493F288E78458063FDA63ED930</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BD25BCAEC40792D702B165DC4E0E4068</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>963D87FDD08BED60C7AAD8238A147DD1</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Realm.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>970D6045BECE13C47427CE89CDF56132</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89F0037B1208F4778B38B0CFF68348A7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>976B681CB49490257B24B748167EE9F5</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>8A4E5A63C89400E1B3EE4D720E49F86F</string>
+				<string>FC6DA370156B0CC5579A4EB40228B09A</string>
+				<string>08F6E0C44E12D9CA8DF2DBC5866DE5B5</string>
+				<string>E3CD6EF222114C791F5F8A6F461A0C2D</string>
+				<string>FB4F8753DB9E04DEF61E0036DF03A9D5</string>
+				<string>250D3DADF320E007F9BF93AB25F8A037</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/PathKit</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>977577C045EDA9D9D1F46E2598D19FC7</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9876CDDD5871A75252FFE47200F82C84</key>
+		<dict>
+			<key>fileRef</key>
+			<string>ED8762338AC853B059F0078B7BF54C74</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>999AC8D622FC0F2C1073826143685189</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CAD5C8EFBD82FCA7F4C711DDCE626676</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>999C6BE75E407953D138E873E91D3E21</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMRealmConfiguration.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMRealmConfiguration.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>99AE3C32FB99FCA39E72BF9F82496DEE</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1AE19F1FFD4B623527C27BF05D2BF31D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>9A5A17348B4D0E60ABAA4D040EA8DFED</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>object_schema.cpp</string>
+			<key>path</key>
+			<string>Realm/ObjectStore/object_schema.cpp</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9A88B67BA53DC06138354AE4AB06BBEC</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>59F03CA5F870A59A7DC4FE571FF85A80</string>
+				<string>A68A5681C548CA29D8B6854F430B46FA</string>
+				<string>A970B9FC0E0B15EB134A53D39BA938E3</string>
+				<string>43103CF0EDC745ED1FABF936B4334F8D</string>
+				<string>A0496BBB3CF3A07D65946972DDCB906C</string>
+				<string>1020DC3FBB8E70DE1DAE17C97E85333E</string>
+				<string>7F457A03F9AAC050288B25C55486010D</string>
+				<string>B8AE37511CF793AD65D0B6411DE3C4D1</string>
+				<string>BD25BCAEC40792D702B165DC4E0E4068</string>
+				<string>A30A2A989CC72FB4D46E1C18FEAC1E4B</string>
+				<string>AB0FBCDE4D353AAC203D8510CD88849D</string>
+				<string>1CAF6C55A82A67E4B3D1003CFB3369A9</string>
+				<string>1613577FE131ADE567FBD6DF6F3FDA70</string>
+				<string>EDAA7BD525EAC1621E00BCBC3E8C1EC5</string>
+				<string>999C6BE75E407953D138E873E91D3E21</string>
+				<string>4B1F27CAFD4C276D9D74B2A933F3CB45</string>
+				<string>7B77BF0083B2A3FE0247DC63E8C16CA0</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Headers</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9A9B0D7B92D1264ADC6F9EDAEF1FDCAE</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1E0615CF56088C501D87706816F66F05</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>9ABC69341A34F40BBD661AE423D06E3E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMOptionalBase.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMOptionalBase.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9BD3D7793D7ED32F397541EB7A03ADAF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CBC0335B8B9B9D0BA1CC6AF6495929D9</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Private</string>
+				</array>
+			</dict>
+		</dict>
+		<key>9C1E65AD80D079676A8F578109A642BC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9C322452B27A96368ACC916DB4EACE9D</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>SSZipArchive.framework</string>
+			<key>path</key>
+			<string>SSZipArchive.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>9C4C5DD30F6807E5CAA0686C21363E4C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>3BD2BCEDFB78A820E986BC125AB99112</string>
+				<string>55EB30039FA973FA56CBC419DE912DC7</string>
+				<string>F12D867DADEF9CF1B5E8F866B13DFF9B</string>
+				<string>3530DBF75398985B0150C5517334CD82</string>
+				<string>05A29D9811FE50FC553EE8380C12A459</string>
+				<string>AA9EAB656A53E3220431CE36DEB9683C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>TGSpreadsheetWriter</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9C757FF507346A6EB9D2540C8E620D79</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Realm.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>9E3042C037127666D3EC4870E35931F1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>55EB30039FA973FA56CBC419DE912DC7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>9E563B38E40DB43E6C8718B0C2BE9E2A</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RealmConverter.framework</string>
+			<key>path</key>
+			<string>RealmConverter.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>9E8AD47E2D34FE19688243E5F1328F63</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>Realm.framework</string>
+			<key>path</key>
+			<string>Realm.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>9F183C647578D111DF61F06BBFF6143E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>70153F79B788A90BC4A9E3679583D60D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>9F93B849606BA632862F620388F1CD71</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DB255E01E754531C0F73C07C6ECAACC1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>A02FB283C242F581628F1E1860C29BA3</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMArrayLinkView.mm</string>
+			<key>path</key>
+			<string>Realm/RLMArrayLinkView.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A042AC754D95496EB6398473225A7078</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AppSandboxFileAccessPersist.h</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess/Classes/AppSandboxFileAccessPersist.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A0496BBB3CF3A07D65946972DDCB906C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMDefines.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMDefines.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A070F153A04DD66F4E492261894B37FF</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>RELEASE=1</string>
+				</array>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>STRIP_INSTALLED_PRODUCT</key>
+				<string>NO</string>
+				<key>SYMROOT</key>
+				<string>${SRCROOT}/../build</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>A086A964EFA9C3A7879C3129B759FFCE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>AppSandboxFileAccess.m</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess/Classes/AppSandboxFileAccess.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A19421B9966A85C3EAC8DDC4FBCFCAF9</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMProperty.mm</string>
+			<key>path</key>
+			<string>Realm/RLMProperty.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A1DA738A84039E33733961E6B3E317D9</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>AppSandboxFileAccessPersist.m</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess/Classes/AppSandboxFileAccessPersist.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A1E90C16CA7394ABAE6952B4887A7B81</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>292BD8561A4227D74CE3A2DF1D05982E</string>
+			<key>buildPhases</key>
+			<array>
+				<string>171FADCEA90F391D40CA8776AF062C75</string>
+				<string>A1F85F7C52B80C457B84DCE87858EF1D</string>
+				<string>0B8A9B8E14DFE9738C956468F7529231</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>C2A28F6F733D91ED94FC1F57AF8F4CA5</string>
+				<string>4C8CAF8A978D57B8BE208E8D5C3E2B6B</string>
+				<string>62C959111EA36C35E395743533B36D13</string>
+				<string>7FF4D278CDAE2B74A777F0EA935C4A4E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>RealmConverter</string>
+			<key>productName</key>
+			<string>RealmConverter</string>
+			<key>productReference</key>
+			<string>9E563B38E40DB43E6C8718B0C2BE9E2A</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>A1F85F7C52B80C457B84DCE87858EF1D</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>AB463BFDEF905F5059456498455BECEA</string>
+				<string>AF05BE9D1B49B2BFE46731DBC4D3B017</string>
+				<string>CBAD2B66321765D0F602D8546BA70B86</string>
+				<string>839C6F803412E9E34416A049CB85BD85</string>
+				<string>904335DE07D1D67885592BA72317EEAC</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>A2E224763DAA078EE22DC2EF01A9B1F6</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Cocoa.framework</string>
+			<key>path</key>
+			<string>Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/Cocoa.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>A2FD0A3B9B6479962E5C7B9BCD2B2EEA</key>
+		<dict>
+			<key>fileRef</key>
+			<string>F4E4D5458A3957A50C451BDD460A8146</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>A30A2A989CC72FB4D46E1C18FEAC1E4B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMObjectSchema.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMObjectSchema.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A3F3D3E4246FB153A3C238A0890D8C7A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMObjectStore.mm</string>
+			<key>path</key>
+			<string>Realm/RLMObjectStore.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A4B31E88AF7B67FD8EB4CB9D9E049F9A</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>A72F6E679B47FA5BD09F2A9515288036</string>
+				<string>794ADD6313E9489BEC5E61A3457BC749</string>
+				<string>357D4F9B5F22AEB1F51AC790B0DE05C9</string>
+				<string>F26D7088043EDB28FC0D9C7ACEB6AC57</string>
+				<string>B46FF231A9ED26AC96F3200492562CEC</string>
+				<string>25601A4F933B0288BA887045FAD4DB8A</string>
+				<string>3B0EE4ACCD03BBF2440A3693C074066C</string>
+				<string>AFF0DE37AF5F2ACAF91FB1D3D2DE329B</string>
+				<string>57CDBDC59BAED9EACDBECDCA5129FD7B</string>
+				<string>E29C0C24B7ADE76C71CCCEAC37FB4D19</string>
+				<string>3FC698B87150A428B273817AA134E9A5</string>
+				<string>14E8241278CA6C4ED286431E1BDCF9F2</string>
+				<string>5B0A178E457A92024A18B74C29DD577C</string>
+				<string>95E6F9493F288E78458063FDA63ED930</string>
+				<string>ACD8B8D4E93FBEB126BE3970FB377C17</string>
+				<string>3E7DDF75C64B7C507AF21ED0B97FA016</string>
+				<string>F7435CF4F860EB2FC48BF128CB315A71</string>
+				<string>C5BEA4C7CAC26163DFE867E0510006E7</string>
+				<string>1055889BAFAFD6054D7B61D9614CFC8E</string>
+				<string>EA9AFA5D4BDF826B46132B8949545DD0</string>
+				<string>78886685330CBFF0AFA0004658A5B4C5</string>
+				<string>855857FDF0A68C81EE20F8AFF89A998D</string>
+				<string>4ADAC9B7313F63B34197CA1F4A9E9C72</string>
+				<string>9BD3D7793D7ED32F397541EB7A03ADAF</string>
+				<string>B453E7A00408F4A77F033EDBD665E0ED</string>
+				<string>50743BC1BE695769AC87A79B2D7F0D82</string>
+				<string>D85E6244F76B7F8B12D4D391494C549E</string>
+				<string>DC2E40164119E256D7CD886FE068C029</string>
+				<string>F3FB5656F92619F47C6C5F3967907E13</string>
+				<string>446866786867E9531A8AF2C25EED58D7</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>A4DD38ED53EACDC80805C488A95210BA</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>09D4AA5011C7C94D70BCEEDD2DD935DF</string>
+				<string>CF4AD6AAD96373B95789F35D8E9D3785</string>
+				<string>D2FB1939848665F80BA9A114A3F79A8D</string>
+				<string>EB301B35774250D9DAF20A1BAFAC6914</string>
+				<string>D0B5097631EF99C0653439E1100F94E1</string>
+				<string>2282975F057A6767A8F330DC75192839</string>
+				<string>E68BB55BC804EA907D8B5534ECCB03EB</string>
+				<string>10E29DDE9550025C74EA23C7E4CEF0F7</string>
+				<string>970D6045BECE13C47427CE89CDF56132</string>
+				<string>511F4A56904027806B5D5027A81ABB02</string>
+				<string>3B6D4BAA76130B9A44305448F6A766BC</string>
+				<string>6315AC8453D02A3FD59F9F71F364EA46</string>
+				<string>B934A7BE0B67E9AB2143755F3388AC62</string>
+				<string>B5CC27E512BE35B3C19918582A3F1FD6</string>
+				<string>F5A9E0302889F8E71A9B4C9F42484862</string>
+				<string>2EBD35649FB2E40FF0EEB5E150F57A0B</string>
+				<string>AA867865E78E83FEA0E3998A8CE7EAAC</string>
+				<string>ACC6BDC6C06EB57F55D1AFC39749FD6D</string>
+				<string>A2FD0A3B9B6479962E5C7B9BCD2B2EEA</string>
+				<string>314AF406EAE652723D243081FFC5B55D</string>
+				<string>E2CC6849183CBD5E289DEA7828844947</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>A4F7C8A2EA6831936F500EDD988D5685</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DAB7D91BBCF663D88A2F0482906EB695</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>A5A585A14DEE51BD017795B9A5BFF371</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AppSandboxFileAccessOpenSavePanelDelegate.h</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess/Classes/AppSandboxFileAccessOpenSavePanelDelegate.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A5B7328037649BCBEE8E293C6030C4BC</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>0DFDC22D11F2D25D7BC65BA79C0C8FC9</string>
+			<key>remoteInfo</key>
+			<string>SSZipArchive</string>
+		</dict>
+		<key>A68A5681C548CA29D8B6854F430B46FA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMArray.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMArray.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A72F6E679B47FA5BD09F2A9515288036</key>
+		<dict>
+			<key>fileRef</key>
+			<string>59F03CA5F870A59A7DC4FE571FF85A80</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>A8429AF4EF3E7FBCBE758A1200B23AE7</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>aeskey.c</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/aeskey.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A877F61198EF32BBAF3625076D9467D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4E95F14A837F5530701D153685999E18</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>A878C683463E5D95C28E7DF9A2068391</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>AppSandboxFileAccessOpenSavePanelDelegate.m</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess/Classes/AppSandboxFileAccessOpenSavePanelDelegate.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A970B9FC0E0B15EB134A53D39BA938E3</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMCollection.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMCollection.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>AA353BA701BC4981916B046E80579AFF</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>brg_endian.h</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/brg_endian.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>AA867865E78E83FEA0E3998A8CE7EAAC</key>
+		<dict>
+			<key>fileRef</key>
+			<string>44A1469F401CF6008E8A2F3F60BC10BD</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>AA9EAB656A53E3220431CE36DEB9683C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>673F8575BD473AF5AF685151CDCC192A</string>
+				<string>3CC1D2825DD2D70DFC5C97B33482B657</string>
+				<string>8A26F9EF39256FD631BD62725E2402F7</string>
+				<string>1C39AF29E5B53613D57105A4F510B0CD</string>
+				<string>1073FCE14723DD4CBB3C65F83CBF7FDF</string>
+				<string>5F35DD12E0FAF85C747FB80152808849</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/TGSpreadsheetWriter</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>AAE0D156249D94D4B7EA6573E78BECF5</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>pwd2key.h</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/pwd2key.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>AB0FBCDE4D353AAC203D8510CD88849D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMPlatform.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMPlatform.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>AB463BFDEF905F5059456498455BECEA</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A2E224763DAA078EE22DC2EF01A9B1F6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>AC4DB82A899509932498571314464BF1</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>SSZipArchive-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>ACC6BDC6C06EB57F55D1AFC39749FD6D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>7CF4D42A8F0D4F169E76D4E90E5C74C0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>ACD8B8D4E93FBEB126BE3970FB377C17</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A30A2A989CC72FB4D46E1C18FEAC1E4B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>AED3600F6B88D062A901C0D2EBCC7752</key>
+		<dict>
+			<key>fileRef</key>
+			<string>AFFAACC04CCAFAC7EF65AE188FFE14F6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>AF05BE9D1B49B2BFE46731DBC4D3B017</key>
+		<dict>
+			<key>fileRef</key>
+			<string>745CFE9844D5ADA3FA496AF4EA9A2391</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>AFF0DE37AF5F2ACAF91FB1D3D2DE329B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3803D882518A91345A998713852DBFE9</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>AFFAACC04CCAFAC7EF65AE188FFE14F6</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SSZipArchive.m</string>
+			<key>path</key>
+			<string>SSZipArchive/SSZipArchive.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B11AE06127E3E224E76102D875C6CA29</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DFA0C81489C637F0DA69EB1F54B6AEE5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>B15FBB607E84631F78CA08362B96CCFC</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>52DFB13C140C3580E039585DE95F297C</string>
+				<string>40D1A523009273CD0AC912C47B7371A7</string>
+				<string>330511F3C7FE8CB73C875F331FB890D2</string>
+				<string>FEC311E12DB84B8600A60E9FBA3799E0</string>
+				<string>57095DD99474AD41DE3EEB4BE6F2D34E</string>
+				<string>1EFED74A2EBBF8322E32677C9304BE56</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/RealmConverter</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B172BF9C9A298326CB45BFA2D3FBD2DA</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>8A26F9EF39256FD631BD62725E2402F7</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/TGSpreadsheetWriter/TGSpreadsheetWriter-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/TGSpreadsheetWriter/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/TGSpreadsheetWriter/TGSpreadsheetWriter.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>TGSpreadsheetWriter</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>B1ECB794421C4581658AE60E13BEA337</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>Encoding.swift</string>
+			<key>path</key>
+			<string>RealmConverter/Support/Encoding.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B1FCEDB643FAF9E812BD22FC813BA25A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess-umbrella.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B21FF966A642F7DF524A2FFD92271B27</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>CSVDataImporter.swift</string>
+			<key>path</key>
+			<string>RealmConverter/Importer/CSVDataImporter.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B28738B7DBEFB9D43FC99EF9818A6916</key>
+		<dict>
+			<key>fileRef</key>
+			<string>F12D867DADEF9CF1B5E8F866B13DFF9B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>B4231AE1512289C8EA19666DD531F5B4</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>crypt.h</string>
+			<key>path</key>
+			<string>SSZipArchive/minizip/crypt.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B453E7A00408F4A77F033EDBD665E0ED</key>
+		<dict>
+			<key>fileRef</key>
+			<string>999C6BE75E407953D138E873E91D3E21</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>B46FF231A9ED26AC96F3200492562CEC</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A970B9FC0E0B15EB134A53D39BA938E3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>B47485278D763CEF443861F6FBA92B65</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>0DFDC22D11F2D25D7BC65BA79C0C8FC9</string>
+			<key>remoteInfo</key>
+			<string>SSZipArchive</string>
+		</dict>
+		<key>B52762951A1DBC3E77A33ABD829FEE0D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>results.cpp</string>
+			<key>path</key>
+			<string>Realm/ObjectStore/results.cpp</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B53D6206CA911D031F8053FC6636C7B1</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>SSZipArchive-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B5CC27E512BE35B3C19918582A3F1FD6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4135B47426BBD4B027107FDD7DEFB3FB</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>B71ABEDF6A3C3AA1CC4AC880C7BC8A86</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B7B80995527643776607AFFA75B91E24</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>75D98FF52E597A11900E131B6C4E1ADA</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Targets Support Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B80B0212901845EC122FCFCAF660DB1D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B1FCEDB643FAF9E812BD22FC813BA25A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>B8AE37511CF793AD65D0B6411DE3C4D1</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMObjectBase.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMObjectBase.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B8C4745957C099E9682B5181B1928187</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>hmac.c</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/hmac.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B90C49FBE7F9F113C5E6D0F4023F1E63</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>08F6E0C44E12D9CA8DF2DBC5866DE5B5</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/PathKit/PathKit-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/PathKit/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/PathKit/PathKit.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>PathKit</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>B934A7BE0B67E9AB2143755F3388AC62</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DE7AD83A17E01FB317130543AB9C44A6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>BA055B534BD93E1154E785ED24765C0D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>72176F811D85F6AE2E7BF90CBD601644</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BA6428E9F66FD5A23C0A2E06ED26CD2F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>name</key>
+			<string>Podfile</string>
+			<key>path</key>
+			<string>../Podfile</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.ruby</string>
+		</dict>
+		<key>BA7B2DACB5CF0834E1B165A0BED8854E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>FD499AC05B2273EEBB6CCEACDFB0D19A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>BC10585B1807C756CDB33F02A382A260</key>
+		<dict>
+			<key>fileRef</key>
+			<string>37EDB653332F73BE50868CAE1799508D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>BD25BCAEC40792D702B165DC4E0E4068</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMObjectBase_Dynamic.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMObjectBase_Dynamic.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BD5F283AA572A97F02CE3C171E17AB24</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B52762951A1DBC3E77A33ABD829FEE0D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>BF080C07656878AAB4897C2BBFA46B13</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>RLMConstants.m</string>
+			<key>path</key>
+			<string>Realm/RLMConstants.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BFA77BE3AF51AA10E6ED8EB65E333A31</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>F8DBBC6BB5AD1EBD4E9C618B36F18963</string>
+			<key>remoteInfo</key>
+			<string>PathKit</string>
+		</dict>
+		<key>C0346FDF36155B025E7FE4B13227A243</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3198887C97EACA777370AE6F188AF829</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>C0ED6A24D351EA7318641F59FA8CC831</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>DataExporter.swift</string>
+			<key>path</key>
+			<string>RealmConverter/Exporter/DataExporter.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C1B856FA1794963765B6B11447040661</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMObservation.mm</string>
+			<key>path</key>
+			<string>Realm/RLMObservation.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C238473D12590CFD4363445513344DFB</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A2E224763DAA078EE22DC2EF01A9B1F6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>C2A28F6F733D91ED94FC1F57AF8F4CA5</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>CSwiftV</string>
+			<key>target</key>
+			<string>C9289771C9E400167D4D291E44982A06</string>
+			<key>targetProxy</key>
+			<string>C6362637BD272EAA7517AF82AFD5AB2B</string>
+		</dict>
+		<key>C394E7920190475674D9AD11760C5165</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>7AC5F2A74AE518C6C97ED0BDB2B27333</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Realm/Realm-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/Realm/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/Realm/Realm.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>Realm</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>C3C4E3105B0FA8266054F37B2AE56540</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMArray_Private.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMArray_Private.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C45BDFFB213CA83E3C74F7C87A0ABDD2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Realm</string>
+			<key>target</key>
+			<string>D0CD4B404F898BAC414372B461A667BF</string>
+			<key>targetProxy</key>
+			<string>CFBF68BD3B74877080C303E00FC0C496</string>
+		</dict>
+		<key>C4B83AB3AD2940C100050FC255571F5B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMObjectSchema_Private.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMObjectSchema_Private.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C5504A46EA0B3A6D2FE2C3911CDFACA4</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMResults_Private.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMResults_Private.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C5BEA4C7CAC26163DFE867E0510006E7</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9ABC69341A34F40BBD661AE423D06E3E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>C6362637BD272EAA7517AF82AFD5AB2B</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>C9289771C9E400167D4D291E44982A06</string>
+			<key>remoteInfo</key>
+			<string>CSwiftV</string>
+		</dict>
+		<key>C7DE9DCC709D99E2D78137CE68DA06EB</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>sha1.c</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/sha1.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C8CC732936FA19529773DD3C751FFF2C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>SSZipArchive.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C9200253A8AE36C3AB6DEFE3AC62C075</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RealmConverter.h</string>
+			<key>path</key>
+			<string>RealmConverter/RealmConverter.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C9289771C9E400167D4D291E44982A06</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>5C1BD6FAFE8954E49C824D5580F07BD7</string>
+			<key>buildPhases</key>
+			<array>
+				<string>0FE1818D5B2E830251E4C81F395EA7AA</string>
+				<string>8621E5C1CB20FA11CB771D77FB7B3AD2</string>
+				<string>3A71C16CE157664F75F922991BA623FF</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>CSwiftV</string>
+			<key>productName</key>
+			<string>CSwiftV</string>
+			<key>productReference</key>
+			<string>8A293A690C61C7D33120456C1774581A</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>C95637F789EB1F555F898F9A90279731</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A2E224763DAA078EE22DC2EF01A9B1F6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>C9CC55C4090A94AA1201659BA0C984AC</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>2E428116A40B080D11E84AB8F6BCD7A5</string>
+				<string>D822F3F5388DA53393ED93B9350C5702</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>CA2671F2B70D86BCD5122CC8E8FE286B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3824AA76DE171EAD9ACF0C6BA55B45D3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>CAD5C8EFBD82FCA7F4C711DDCE626676</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>XLSXDataImporter.swift</string>
+			<key>path</key>
+			<string>RealmConverter/Importer/XLSXDataImporter.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CBAD2B66321765D0F602D8546BA70B86</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2E85BD6029B5A4E38247B8133FA951E9</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CBC0335B8B9B9D0BA1CC6AF6495929D9</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMRealm_Private.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMRealm_Private.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CBC0F7C552B739C909B650A0F42F7F38</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-resources.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CC0E23DC1A89303BD763AF75D5CFEC85</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B21FF966A642F7DF524A2FFD92271B27</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CEEBF007167B3D3AC4331C4FF75C020B</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>0CBF82A7A39169D30B8A20E7229E7A18</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/AppSandboxFileAccess/AppSandboxFileAccess-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/AppSandboxFileAccess/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/AppSandboxFileAccess/AppSandboxFileAccess.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>AppSandboxFileAccess</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>CF2E9B7C1D862BB5667287B02F918198</key>
+		<dict>
+			<key>fileRef</key>
+			<string>86961DC4D50C3885E3F4A6B9039F2554</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>CF4AD6AAD96373B95789F35D8E9D3785</key>
+		<dict>
+			<key>fileRef</key>
+			<string>716C4A29792DD68A1977222812EEF84D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>CFBF68BD3B74877080C303E00FC0C496</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>D0CD4B404F898BAC414372B461A667BF</string>
+			<key>remoteInfo</key>
+			<string>Realm</string>
+		</dict>
+		<key>D0405803033A2A777B8E4DFA0C1800ED</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>path</key>
+			<string>Pods-acknowledgements.markdown</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D0B5097631EF99C0653439E1100F94E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>AA353BA701BC4981916B046E80579AFF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>D0CD4B404F898BAC414372B461A667BF</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>F168664D938992F047DA4455117ACE52</string>
+			<key>buildPhases</key>
+			<array>
+				<string>3B11CBFD65D8885258193DF1B63B1F80</string>
+				<string>EAE26F5FFCA07C906946B3B3354CD3F3</string>
+				<string>A4B31E88AF7B67FD8EB4CB9D9E049F9A</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Realm</string>
+			<key>productName</key>
+			<string>Realm</string>
+			<key>productReference</key>
+			<string>9E8AD47E2D34FE19688243E5F1328F63</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>D1F93CEB80733991DDF579E93A392F60</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BF080C07656878AAB4897C2BBFA46B13</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>D24235CDF995FC31A2897A5A7283FC5E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMMigration.mm</string>
+			<key>path</key>
+			<string>Realm/RLMMigration.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D2FB1939848665F80BA9A114A3F79A8D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2F441B555B2179F592E1CBA38663A808</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>D41D8CD98F00B204E9800998ECF8427E</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>LastSwiftUpdateCheck</key>
+				<string>0700</string>
+				<key>LastUpgradeCheck</key>
+				<string>0700</string>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>2D8E8EC45A3A1A1D94AE762CB5028504</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+			</array>
+			<key>mainGroup</key>
+			<string>7DB346D0F39D3F0E887471402A8071AB</string>
+			<key>productRefGroup</key>
+			<string>4D9F3C0F8F127C1F302BA2C94EBD2AC6</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array/>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>0431D34712EA2D1E2771AA4D24AB3848</string>
+				<string>C9289771C9E400167D4D291E44982A06</string>
+				<string>F8DBBC6BB5AD1EBD4E9C618B36F18963</string>
+				<string>0644799C31F10982A95C7FE6959F12BC</string>
+				<string>D0CD4B404F898BAC414372B461A667BF</string>
+				<string>A1E90C16CA7394ABAE6952B4887A7B81</string>
+				<string>0DFDC22D11F2D25D7BC65BA79C0C8FC9</string>
+				<string>1C77996166FA926760F5CA781567DE18</string>
+			</array>
+		</dict>
+		<key>D478998D346D9B7B148CCA1D90F73C62</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2BCC458FDD5F692BBB2BFC64BB5701FC</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>D5165BCE41EC813689C4C6F4F29CC3C6</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AppSandboxFileAccess.h</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess/Classes/AppSandboxFileAccess.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D69800DBB23F2122BC215A5EE42B9FAD</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A3F3D3E4246FB153A3C238A0890D8C7A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>D6D9453A1A3FF2248860EB52453B2474</key>
+		<dict>
+			<key>fileRef</key>
+			<string>5A24BC47325BB22483160927840DA2CC</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>D822F3F5388DA53393ED93B9350C5702</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3530DBF75398985B0150C5517334CD82</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>D85E6244F76B7F8B12D4D391494C549E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4B1F27CAFD4C276D9D74B2A933F3CB45</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>DA312349A49333542E6F4B36B329960E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DA5ED5C1DFC5BC211B5C49E01B1360C1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>14EFD886E4361BC20FB65E7089303D8B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>DA9DB603212261629EE155B9D9953AEB</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27DB5238F29570F7A603A75A91C32A54</string>
+				<string>82EF335C7BBCC60AEE64B430F4B9DF08</string>
+				<string>DBE7F0C00830063060771EF7F00929D9</string>
+				<string>1B394ACA1CE40F9DFC609B41FAA13E77</string>
+				<string>4E95F14A837F5530701D153685999E18</string>
+				<string>5C5DAF1B2F9D5EF96A9DDD60D0BB5BDC</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/CSwiftV</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DAB7D91BBCF663D88A2F0482906EB695</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMObject.mm</string>
+			<key>path</key>
+			<string>Realm/RLMObject.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DB255E01E754531C0F73C07C6ECAACC1</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMQueryUtil.mm</string>
+			<key>path</key>
+			<string>Realm/RLMQueryUtil.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DBAA40395ABA7E82959ACE18C59290F5</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>78DC08D48DBEF104EB2C2CCAC2272EB7</string>
+				<string>B90C49FBE7F9F113C5E6D0F4023F1E63</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>DBB05F4BA4BADCFFC489810FA229A121</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.swift</string>
+			<key>name</key>
+			<string>String+CamelCase.swift</string>
+			<key>path</key>
+			<string>RealmConverter/Support/String+CamelCase.swift</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DBE7F0C00830063060771EF7F00929D9</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>CSwiftV-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DC2E40164119E256D7CD886FE068C029</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C5504A46EA0B3A6D2FE2C3911CDFACA4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Private</string>
+				</array>
+			</dict>
+		</dict>
+		<key>DC317A257FA26430E2747B489CD6B09C</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>C8CC732936FA19529773DD3C751FFF2C</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/SSZipArchive/SSZipArchive-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/SSZipArchive/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/SSZipArchive/SSZipArchive.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>SSZipArchive</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>DC831F65978C85088F18DA16200C453C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E84A16B2DD844599EC3037DA81D2038D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>DCE2B1A050EB5CEEA7ADDCD3C05F54E0</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMSchema_Private.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMSchema_Private.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DCE6244F4798467314F0547A1598949D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E3CD6EF222114C791F5F8A6F461A0C2D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DE210B0FAF0C41A54011E0736706C9AD</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A8429AF4EF3E7FBCBE758A1200B23AE7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DOS_OBJECT_USE_OBJC=0</string>
+			</dict>
+		</dict>
+		<key>DE7AD83A17E01FB317130543AB9C44A6</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>mztools.h</string>
+			<key>path</key>
+			<string>SSZipArchive/minizip/mztools.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DFA0C81489C637F0DA69EB1F54B6AEE5</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMResults.mm</string>
+			<key>path</key>
+			<string>Realm/RLMResults.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E1AC9B1FE18A1562F9378EC7DFAD8648</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1DDDA9921A7144720EB431B6CAF58571</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>E22CE0498E06FD67D741E59D96E720A5</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>aestab.c</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/aestab.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E29C0C24B7ADE76C71CCCEAC37FB4D19</key>
+		<dict>
+			<key>fileRef</key>
+			<string>21B59C1A4A3C949D88977978CDDCD0DF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Private</string>
+				</array>
+			</dict>
+		</dict>
+		<key>E2CC6849183CBD5E289DEA7828844947</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4B67266F7743232CEEA01857DEFCDC88</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>E3542F21C12A8F20472B801BE260DDEF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B53D6206CA911D031F8053FC6636C7B1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>E3CD6EF222114C791F5F8A6F461A0C2D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>PathKit-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E5B093DC83F76FEFCEFED39FB79A8DCC</key>
+		<dict>
+			<key>fileRef</key>
+			<string>54C8EB611A0A77E462591BD7970E7968</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>E68BB55BC804EA907D8B5534ECCB03EB</key>
+		<dict>
+			<key>fileRef</key>
+			<string>54C6E0D9A39100A1B977F6AA98B6B498</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>E704B906C21A38A983C00338833CFC7D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3BD2BCEDFB78A820E986BC125AB99112</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>E7F21354943D9F42A70697D5A5EF72E9</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-frameworks.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E8004BC3C383BE4026064214ABE245DD</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>12189A8DE8928260ECB0D0A3B97ED120</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E8446514FBAD26C0E18F24A5715AEF67</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E84A16B2DD844599EC3037DA81D2038D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMPredicateUtil.mm</string>
+			<key>path</key>
+			<string>Realm/RLMPredicateUtil.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E8ACF4880ADBCEE4708B9C01F80E5529</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>TGSpreadsheetWriter</string>
+			<key>target</key>
+			<string>1C77996166FA926760F5CA781567DE18</string>
+			<key>targetProxy</key>
+			<string>65FD849FE888931EF384B7D5C09AB7A5</string>
+		</dict>
+		<key>E8F0FAF691DC0C086DC7853A35838DA2</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>330511F3C7FE8CB73C875F331FB890D2</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/RealmConverter/RealmConverter-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/RealmConverter/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/RealmConverter/RealmConverter.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>RealmConverter</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>EA6036ECAB6EEBF91FEF6A6D49ABB6FF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>D24235CDF995FC31A2897A5A7283FC5E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@"0.98.6"' -D__ASSERTMACROS__</string>
+			</dict>
+		</dict>
+		<key>EA9AFA5D4BDF826B46132B8949545DD0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1CAF6C55A82A67E4B3D1003CFB3369A9</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>EAE26F5FFCA07C906946B3B3354CD3F3</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>C95637F789EB1F555F898F9A90279731</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>EB301B35774250D9DAF20A1BAFAC6914</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2F99C81EE3FD403B46B3F5D39C6B71D0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>EB9A01C742FE18F233430751C19EAE7B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DBB05F4BA4BADCFFC489810FA229A121</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EC4E64AD48AAF9E2943ACB390398369A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A2E224763DAA078EE22DC2EF01A9B1F6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>ED8762338AC853B059F0078B7BF54C74</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>realm_coordinator.cpp</string>
+			<key>path</key>
+			<string>Realm/ObjectStore/impl/realm_coordinator.cpp</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EDAA7BD525EAC1621E00BCBC3E8C1EC5</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>RLMRealm_Dynamic.h</string>
+			<key>path</key>
+			<string>include/Realm/RLMRealm_Dynamic.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EE29625675B175C13FB812E90C9F4025</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>B80B0212901845EC122FCFCAF660DB1D</string>
+				<string>9448EEA86EEF2C88F0678F62B00BB0D1</string>
+				<string>0A47C7CA19CBD3E41CCD34CA089058D4</string>
+				<string>18A26B02BF9CEAF6AAA809AB342B5307</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>EE34A6272512B232D721068FFE5A4D78</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>brg_types.h</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/brg_types.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EE7A46055D614EB4E266A6A8678BA94B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>17650893B51708A441A7FF79DEF2DAD0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EF2985BF643FB0330E23155C2A8CB698</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>82EF335C7BBCC60AEE64B430F4B9DF08</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/CSwiftV/CSwiftV-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/CSwiftV/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/CSwiftV/CSwiftV.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>CSwiftV</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>SWIFT_OPTIMIZATION_LEVEL</key>
+				<string>-Onone</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>F12D867DADEF9CF1B5E8F866B13DFF9B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>TGSpreadsheetWriter.h</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter/TGSpreadsheetWriter.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F14FE9B738330F029E174A12203B83CB</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>0CBF82A7A39169D30B8A20E7229E7A18</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>COMBINE_HIDPI_IMAGES</key>
+				<string>YES</string>
+				<key>CURRENT_PROJECT_VERSION</key>
+				<string>1</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>DEFINES_MODULE</key>
+				<string>YES</string>
+				<key>DYLIB_COMPATIBILITY_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_CURRENT_VERSION</key>
+				<string>1</string>
+				<key>DYLIB_INSTALL_NAME_BASE</key>
+				<string>@rpath</string>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>FRAMEWORK_VERSION</key>
+				<string>A</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/AppSandboxFileAccess/AppSandboxFileAccess-prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Target Support Files/AppSandboxFileAccess/Info.plist</string>
+				<key>INSTALL_PATH</key>
+				<string>$(LOCAL_LIBRARY_DIR)/Frameworks</string>
+				<key>LD_RUNPATH_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>@executable_path/../Frameworks</string>
+					<string>@loader_path/Frameworks</string>
+				</array>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>MODULEMAP_FILE</key>
+				<string>Target Support Files/AppSandboxFileAccess/AppSandboxFileAccess.modulemap</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>PRODUCT_NAME</key>
+				<string>AppSandboxFileAccess</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+				<key>VERSIONING_SYSTEM</key>
+				<string>apple-generic</string>
+				<key>VERSION_INFO_PREFIX</key>
+				<string></string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>F168664D938992F047DA4455117ACE52</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>4AA1CBEE9B262E33B392AF95F56ADC2C</string>
+				<string>C394E7920190475674D9AD11760C5165</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>F26D7088043EDB28FC0D9C7ACEB6AC57</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C3C4E3105B0FA8266054F37B2AE56540</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Private</string>
+				</array>
+			</dict>
+		</dict>
+		<key>F2F5C77F6B8A82BE8F99A87FC3F189A7</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>89D13F76001C05818D50C48B10052874</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>F3184C7D15E1C607B7B9D298339FEA2C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>9C1E65AD80D079676A8F578109A642BC</string>
+				<string>7DCBCBCB4B46B50367FA4493659182A3</string>
+				<string>C8CC732936FA19529773DD3C751FFF2C</string>
+				<string>B53D6206CA911D031F8053FC6636C7B1</string>
+				<string>AC4DB82A899509932498571314464BF1</string>
+				<string>44A1469F401CF6008E8A2F3F60BC10BD</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/SSZipArchive</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F3FB5656F92619F47C6C5F3967907E13</key>
+		<dict>
+			<key>fileRef</key>
+			<string>7B77BF0083B2A3FE0247DC63E8C16CA0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>F42F2F73B04A3EC00CF51F753925309C</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.framework</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>TGSpreadsheetWriter.framework</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>F49D90E43BEB2AA8A737BADDCBAA3087</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Realm-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F4E4D5458A3957A50C451BDD460A8146</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>unzip.h</string>
+			<key>path</key>
+			<string>SSZipArchive/minizip/unzip.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F5263B7FB0B4EF6A2110479832023FF8</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>372D1E999518B8EE3D71FC3340D164A5</string>
+				<string>716C4A29792DD68A1977222812EEF84D</string>
+				<string>31081229799E9933D1976C60F2B8AE47</string>
+				<string>A8429AF4EF3E7FBCBE758A1200B23AE7</string>
+				<string>2F441B555B2179F592E1CBA38663A808</string>
+				<string>E22CE0498E06FD67D741E59D96E720A5</string>
+				<string>2F99C81EE3FD403B46B3F5D39C6B71D0</string>
+				<string>AA353BA701BC4981916B046E80579AFF</string>
+				<string>EE34A6272512B232D721068FFE5A4D78</string>
+				<string>54C6E0D9A39100A1B977F6AA98B6B498</string>
+				<string>B4231AE1512289C8EA19666DD531F5B4</string>
+				<string>8B7EFFBC7FFCD4E65241A123E257CF7F</string>
+				<string>89F0037B1208F4778B38B0CFF68348A7</string>
+				<string>FD49C997C594336277C7D44719D71E59</string>
+				<string>05C969245C1B62E7985DEA4377653C72</string>
+				<string>B8C4745957C099E9682B5181B1928187</string>
+				<string>2E68AE67BA0144854548E9637BE351FF</string>
+				<string>35D92536BDC8AB8DEBA3A5613FC1BFFE</string>
+				<string>1D5BD286B05E51E6578C46A92D09BFC3</string>
+				<string>3198887C97EACA777370AE6F188AF829</string>
+				<string>DE7AD83A17E01FB317130543AB9C44A6</string>
+				<string>86961DC4D50C3885E3F4A6B9039F2554</string>
+				<string>4135B47426BBD4B027107FDD7DEFB3FB</string>
+				<string>06C5909E9BA9F11BC60281FCB528DDC7</string>
+				<string>AAE0D156249D94D4B7EA6573E78BECF5</string>
+				<string>C7DE9DCC709D99E2D78137CE68DA06EB</string>
+				<string>7C6E2396FEF3F056166688C4BFD133CE</string>
+				<string>7CF4D42A8F0D4F169E76D4E90E5C74C0</string>
+				<string>AFFAACC04CCAFAC7EF65AE188FFE14F6</string>
+				<string>70153F79B788A90BC4A9E3679583D60D</string>
+				<string>F4E4D5458A3957A50C451BDD460A8146</string>
+				<string>FD499AC05B2273EEBB6CCEACDFB0D19A</string>
+				<string>3F7A768A0AD58A0C9F06AA6725EF8BDA</string>
+				<string>4B67266F7743232CEEA01857DEFCDC88</string>
+				<string>F3184C7D15E1C607B7B9D298339FEA2C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>SSZipArchive</string>
+			<key>path</key>
+			<string>SSZipArchive</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F52EC04D9DC0AE2842735C7D17BD3787</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>transact_log_handler.cpp</string>
+			<key>path</key>
+			<string>Realm/ObjectStore/impl/transact_log_handler.cpp</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F5A9E0302889F8E71A9B4C9F42484862</key>
+		<dict>
+			<key>fileRef</key>
+			<string>AAE0D156249D94D4B7EA6573E78BECF5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Project</string>
+				</array>
+			</dict>
+		</dict>
+		<key>F7435CF4F860EB2FC48BF128CB315A71</key>
+		<dict>
+			<key>fileRef</key>
+			<string>68FF1B6FC0C6DE4F36B50D5E4E87AFF8</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Private</string>
+				</array>
+			</dict>
+		</dict>
+		<key>F747F3DE19CA8FAEC9200499DDC99123</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>30B394005B43898E7D40C54F8CD2D80E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>F8DBBC6BB5AD1EBD4E9C618B36F18963</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>DBAA40395ABA7E82959ACE18C59290F5</string>
+			<key>buildPhases</key>
+			<array>
+				<string>23795EC4A07A1F30584DA72FCC4C0DF2</string>
+				<string>FDE4BD31022A5A84F0CA297BF78DC225</string>
+				<string>91E668A10ED64B9B8A379425DED52829</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>PathKit</string>
+			<key>productName</key>
+			<string>PathKit</string>
+			<key>productReference</key>
+			<string>550A6586B95D3032173E6F1A20C6F049</string>
+			<key>productType</key>
+			<string>com.apple.product-type.framework</string>
+		</dict>
+		<key>FA2B9B51D5095FB9B92784C1A76782D5</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AppSandboxFileAccess-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>FB4F8753DB9E04DEF61E0036DF03A9D5</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>PathKit-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>FC6DA370156B0CC5579A4EB40228B09A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>PathKit.modulemap</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>FC70D2C69CFEAFBE595CF4B7A74BF947</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>RLMOptionalBase.mm</string>
+			<key>path</key>
+			<string>Realm/RLMOptionalBase.mm</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>FD499AC05B2273EEBB6CCEACDFB0D19A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>zip.c</string>
+			<key>path</key>
+			<string>SSZipArchive/minizip/zip.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>FD49C997C594336277C7D44719D71E59</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>fileenc.c</string>
+			<key>path</key>
+			<string>SSZipArchive/aes/fileenc.c</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>FDE4BD31022A5A84F0CA297BF78DC225</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>92C77F228BD83616B71F63BD4DB0E24A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>FE8DCA83B5CB285A4648176190034C00</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>SSZipArchive</string>
+			<key>target</key>
+			<string>0DFDC22D11F2D25D7BC65BA79C0C8FC9</string>
+			<key>targetProxy</key>
+			<string>B47485278D763CEF443861F6FBA92B65</string>
+		</dict>
+		<key>FEC311E12DB84B8600A60E9FBA3799E0</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>RealmConverter-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>D41D8CD98F00B204E9800998ECF8427E</string>
+</dict>
+</plist>

--- a/Pods/Realm/build.sh
+++ b/Pods/Realm/build.sh
@@ -20,7 +20,7 @@ set -e
 : ${XCMODE:=xcodebuild} # must be one of: xcodebuild (default), xcpretty, xctool
 
 # Provide a fallback value for TMPDIR, relevant for Xcode Bots
-: ${TMPDIR:=getconf DARWIN_USER_TEMP_DIR}
+: ${TMPDIR:=$(getconf DARWIN_USER_TEMP_DIR)}
 
 PATH=/usr/libexec:$PATH
 
@@ -244,7 +244,7 @@ build_docs() {
     local objc="--objc"
 
     if [[ "$language" == "swift" ]]; then
-        : ${REALM_SWIFT_VERSION:=2.1.1}
+        : ${REALM_SWIFT_VERSION:=2.2}
         sh build.sh set-swift-version
         xcodebuild_arguments="-scheme,RealmSwift"
         module="RealmSwift"
@@ -254,6 +254,7 @@ build_docs() {
     touch Realm/RLMPlatform.h # jazzy will fail if it can't find all public header files
     jazzy \
       ${objc} \
+      --swift-version 2.2 \
       --clean \
       --author Realm \
       --author_url https://realm.io \
@@ -647,6 +648,11 @@ case "$COMMAND" in
         ;;
 
     "verify-cocoapods")
+        pod spec lint Realm.podspec
+        # allow warnings in the Swift podspec because there's no way to
+        # prevent the typealias->associatedtype deprecation warning without
+        # also breaking backwards compatibility with previous Swift 2.x versions
+        pod spec lint RealmSwift.podspec --allow-warnings
         cd examples/installation
         sh build.sh test-ios-objc-cocoapods || exit 1
         sh build.sh test-ios-swift-cocoapods || exit 1
@@ -979,7 +985,7 @@ case "$COMMAND" in
         cp -r $(dirname $0)/scripts ${OBJC}
         cd ${OBJC}
         REALM_SWIFT_VERSION=1.2 sh build.sh examples-ios
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh examples-ios
+        REALM_SWIFT_VERSION=2.2 sh build.sh examples-ios
         sh build.sh examples-osx
         cd ..
         rm -rf ${OBJC}
@@ -989,7 +995,7 @@ case "$COMMAND" in
         cp $0 ${SWIFT}
         cp -r $(dirname $0)/scripts ${SWIFT}
         cd ${SWIFT}
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh examples-ios-swift
+        REALM_SWIFT_VERSION=2.2 sh build.sh examples-ios-swift
         cd ..
         rm -rf ${SWIFT}
         ;;
@@ -1003,9 +1009,9 @@ case "$COMMAND" in
         move_to_clean_dir build/ios-static/Realm.framework xcode-6
         rm -rf build
 
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh prelaunch-simulator
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh test-ios-static
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh ios-static
+        REALM_SWIFT_VERSION=2.2 sh build.sh prelaunch-simulator
+        REALM_SWIFT_VERSION=2.2 sh build.sh test-ios-static
+        REALM_SWIFT_VERSION=2.2 sh build.sh ios-static
         move_to_clean_dir build/ios-static/Realm.framework xcode-7
 
         zip --symlinks -r build/ios-static/realm-framework-ios.zip xcode-6 xcode-7
@@ -1018,8 +1024,8 @@ case "$COMMAND" in
         move_to_clean_dir build/ios/Realm.framework xcode-6
         rm -rf build
 
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh prelaunch-simulator
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh ios-dynamic
+        REALM_SWIFT_VERSION=2.2 sh build.sh prelaunch-simulator
+        REALM_SWIFT_VERSION=2.2 sh build.sh ios-dynamic
         move_to_clean_dir build/ios/Realm.framework xcode-7
 
         zip --symlinks -r build/ios/realm-dynamic-framework-ios.zip xcode-6 xcode-7
@@ -1027,7 +1033,7 @@ case "$COMMAND" in
 
     "package-osx")
         cd tightdb_objc
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh test-osx
+        REALM_SWIFT_VERSION=2.2 sh build.sh test-osx
 
         cd build/DerivedData/Realm/Build/Products/Release
         zip --symlinks -r realm-framework-osx.zip Realm.framework
@@ -1035,27 +1041,27 @@ case "$COMMAND" in
 
     "package-ios-swift")
         cd tightdb_objc
-        for version in 2.1.1; do
+        for version in 2.2; do
             rm -rf build/ios/Realm.framework
             REALM_SWIFT_VERSION=$version sh build.sh prelaunch-simulator
             REALM_SWIFT_VERSION=$version sh build.sh ios-swift
         done
 
         cd build/ios
-        zip --symlinks -r realm-swift-framework-ios.zip swift-2.1.1
+        zip --symlinks -r realm-swift-framework-ios.zip swift-2.2
         ;;
 
     "package-osx-swift")
         cd tightdb_objc
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh osx-swift
+        REALM_SWIFT_VERSION=2.2 sh build.sh osx-swift
 
         cd build/osx
-        zip --symlinks -r realm-swift-framework-osx.zip swift-2.1.1
+        zip --symlinks -r realm-swift-framework-osx.zip swift-2.2
         ;;
 
     "package-watchos")
         cd tightdb_objc
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh watchos
+        REALM_SWIFT_VERSION=2.2 sh build.sh watchos
 
         cd build/watchos
         zip --symlinks -r realm-framework-watchos.zip Realm.framework
@@ -1063,7 +1069,7 @@ case "$COMMAND" in
 
     "package-watchos-swift")
         cd tightdb_objc
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh watchos-swift
+        REALM_SWIFT_VERSION=2.2 sh build.sh watchos-swift
 
         cd build/watchos
         zip --symlinks -r realm-swift-framework-watchos.zip RealmSwift.framework Realm.framework
@@ -1071,7 +1077,7 @@ case "$COMMAND" in
 
     "package-tvos")
         cd tightdb_objc
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh tvos
+        REALM_SWIFT_VERSION=2.2 sh build.sh tvos
 
         cd build/tvos
         zip --symlinks -r realm-framework-tvos.zip Realm.framework
@@ -1079,7 +1085,7 @@ case "$COMMAND" in
 
     "package-tvos-swift")
         cd tightdb_objc
-        REALM_SWIFT_VERSION=2.1.1 sh build.sh tvos-swift
+        REALM_SWIFT_VERSION=2.2 sh build.sh tvos-swift
 
         cd build/tvos
         zip --symlinks -r realm-swift-framework-tvos.zip RealmSwift.framework Realm.framework
@@ -1162,7 +1168,7 @@ case "$COMMAND" in
             unzip ${WORKSPACE}/realm-examples.zip
             cd examples
             if [[ "${LANG}" == "objc" ]]; then
-                rm -rf ios/swift-2.1.1
+                rm -rf ios/swift-2.2
             else
                 rm -rf ios/objc ios/rubymotion osx
             fi

--- a/Pods/Target Support Files/Realm/Info.plist
+++ b/Pods/Target Support Files/Realm/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.98.5</string>
+  <string>0.98.6</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -170,7 +170,7 @@ NSString * const kRealmKeyOutlineWidthForRealm = @"OutlineWidthForRealm:%@";
                 [self exportAndCompactCopyOfRealmFileAtURL:fileURL];
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [securelyScopedURL stopAccessingSecurityScopedResource];
-                });
+                }); 
             }];
         });
     }];

--- a/RealmBrowser/Support/RLMModelExporter.m
+++ b/RealmBrowser/Support/RLMModelExporter.m
@@ -18,6 +18,7 @@
 
 #import "RLMModelExporter.h"
 @import Realm;
+@import Realm.Private;
 #import <AppSandboxFileAccess/AppSandboxFileAccess.h>
 
 @implementation RLMModelExporter
@@ -206,6 +207,8 @@
         case RLMPropertyTypeObject:
             return property.objectClassName;
     }
+    
+    return nil;
 }
 
 + (BOOL)javaPropertyTypeCanBeMarkedRequired:(RLMPropertyType)type
@@ -224,6 +227,8 @@
         case RLMPropertyTypeDate:
             return YES;
     }
+    
+    return NO;
 }
 
 #pragma mark - Private methods - Objective-C helpers
@@ -337,6 +342,8 @@
         case RLMPropertyTypeObject:
             return YES;
     }
+    
+    return NO;
 }
 
 #pragma mark - Private methods - Swift helpers
@@ -436,6 +443,8 @@
         case RLMPropertyTypeObject:
             return @"/* Error! 'Object' properties should always be optional. Please report this by emailing help@realm.io. */";
     }
+    
+    return nil;
 }
 
 @end

--- a/RealmBrowser/Supporting Files/RealmBrowser-Info.plist
+++ b/RealmBrowser/Supporting Files/RealmBrowser-Info.plist
@@ -42,7 +42,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>68</string>
+	<string>71</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/RealmBrowser/Supporting Files/RealmBrowser-Info.plist
+++ b/RealmBrowser/Supporting Files/RealmBrowser-Info.plist
@@ -38,7 +38,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.98.5</string>
+	<string>0.98.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This PR updates Realm Browser to use Realm 0.98.6 and also adds a minor fix to mitigate compile crashes in Xcode 7.3.