### PR TITLE
Crash-fixes for Mavericks

### DIFF
--- a/RealmBrowser/Views/RLMBasicTableCellView.m
+++ b/RealmBrowser/Views/RLMBasicTableCellView.m
@@ -32,9 +32,15 @@
     textField.translatesAutoresizingMaskIntoConstraints = NO;
     textField.bordered = NO;
     textField.drawsBackground = NO;
-    textField.usesSingleLineMode = YES;
-    textField.lineBreakMode = NSLineBreakByTruncatingTail;
     
+    if ([textField respondsToSelector:@selector(setUsesSingleLineMode:)]) {
+        textField.usesSingleLineMode = YES;
+    }
+    
+    if ([textField respondsToSelector:@selector(setLineBreakMode:)]) {
+        textField.lineBreakMode = NSLineBreakByTruncatingTail;
+    }
+        
     self.textField = textField;
     [self addSubview:textField];
     

--- a/RealmBrowser/Views/RLMNumberTableCellView.m
+++ b/RealmBrowser/Views/RLMNumberTableCellView.m
@@ -81,8 +81,14 @@
     textField.bordered = NO;
     textField.drawsBackground = NO;
     textField.alignment = NSRightTextAlignment;
-    textField.usesSingleLineMode = YES;
-    textField.lineBreakMode = NSLineBreakByTruncatingTail;
+
+    if ([textField respondsToSelector:@selector(setUsesSingleLineMode:)]) {
+        textField.usesSingleLineMode = YES;
+    }
+    
+    if ([textField respondsToSelector:@selector(setLineBreakMode:)]) {
+        textField.lineBreakMode = NSLineBreakByTruncatingTail;
+    }
     
     self.textField = textField;
     [self addSubview:textField];


### PR DESCRIPTION
As reported in https://github.com/realm/realm-browser-osx/issues/146, some of the auto-layout code we added when refactoring the text field code for El Capitan is not available on Mavericks, causing a crash.

This PR adds checks to those particular APIs to ensure they're not called on Mavericks. I tested it in a Mavericks VM to ensure that it stopped the app from crashing, and that there weren't any visual glitches by removing them on Mavericks.