### PR TITLE
Fix compilation error for exported model definitions that have recursive relationships

### DIFF
--- a/RealmBrowser/Support/RLMModelExporter.m
+++ b/RealmBrowser/Support/RLMModelExporter.m
@@ -241,7 +241,7 @@
     // Contents of h-file
     NSMutableString *hContents= [NSMutableString stringWithFormat:@"#import <Foundation/Foundation.h>\n#import <Realm/Realm.h>\n\n"];
     for (RLMObjectSchema *schema in schemas) {
-        [hContents appendFormat:@"@class %@;\n", schema.className];
+        [hContents appendFormat:@"@interface %@ : RLMObject\n@end\n\n", schema.className];
     }
     [hContents appendString:@"\n"];
     
@@ -251,7 +251,7 @@
     [hContents appendString:@"\n\n"];
     
     for (RLMObjectSchema *schema in schemas) {
-        [hContents appendFormat:@"@interface %@ : RLMObject\n\n", schema.className];
+        [hContents appendFormat:@"@interface %@()\n\n", schema.className];
         for (RLMProperty *property in schema.properties) {
             [hContents appendFormat:@"@property %@%@;\n", [self objcNameForProperty:property], property.name];
         }


### PR DESCRIPTION
Fix compilation error for exported model definitions that have recursive relationships
e.g.
```objc
@interface TestObject1 : RLMObject

@property RLMArray<TestObject2 *><TestObject2> *objects;

@end

@interface TestObject2 : RLMObject

@property RLMArray<TestObject1 *><TestObject1> *objects;

@end
```

If models have recursive to-many relationships each other like above, the `Save Objective-C definitions` generate model files that have the following compilation error:
```
Type argument 'TestObject2 *' does not satisfy the bound ('RLMObject *') of type parameter 'RLMObjectType'
```

Because generics type parameter cannot recognize the subclass of the RLMObject from `@class` forwarding declarations.
So use `@interface ...` for forwarding declarations instead `@class`. Then, `class extension` for property declarations.
Like the following:

```objc
@interface TestObject1 : RLMObject
@end

@interface TestObject2 : RLMObject
@end

RLM_ARRAY_TYPE(TestObject1)
RLM_ARRAY_TYPE(TestObject2)

@interface TestObject1()

@property RLMArray<TestObject2 *><TestObject2> *objects;

@end

@interface TestObject2()

@property RLMArray<TestObject1 *><TestObject1> *objects;

@end
```

CC @TimOliver @bdash 