### PR TITLE
we're already @import-ing RealmConverter

### DIFF
--- a/RealmBrowser/Application/RLMApplicationDelegate.m
+++ b/RealmBrowser/Application/RLMApplicationDelegate.m
@@ -25,7 +25,6 @@
 #import "TestClasses.h"
 
 #import <AppSandboxFileAccess/AppSandboxFileAccess.h>
-#import <RealmConverter/RealmConverter.h>
 
 @interface RLMApplicationDelegate ()
 


### PR DESCRIPTION
so there's no need to also import the header