### PR TITLE
Updated file type check for new UTI value

### DIFF
--- a/RealmBrowser/Models/RLMDocument.m
+++ b/RealmBrowser/Models/RLMDocument.m
@@ -18,6 +18,7 @@
 
 #import "RLMDocument.h"
 
+#import "RLMBrowserConstants.h"
 #import "RLMClassNode.h"
 #import "RLMArrayNode.h"
 #import "RLMClassProperty.h"
@@ -42,7 +43,7 @@
     __block BOOL success = NO;
     
     if (self = [super init]) {
-        if (![[typeName lowercaseString] isEqualToString:@"documenttype"]) {
+        if (![[typeName lowercaseString] isEqualToString:kRealmUTIIdentifier]) {
             return nil;
         }
         
@@ -53,7 +54,7 @@
         NSString *lastComponent = [absoluteURL lastPathComponent];
         NSString *extension = [absoluteURL pathExtension];
         
-        if (![[extension lowercaseString] isEqualToString:@"realm"]) {
+        if (![[extension lowercaseString] isEqualToString:kRealmFileExtension]) {
             return nil;
         }
         

--- a/RealmBrowser/Support/RLMBrowserConstants.h
+++ b/RealmBrowser/Support/RLMBrowserConstants.h
@@ -24,6 +24,7 @@ extern const NSInteger kMaxNumberOfFilesAtOnce;
 extern const CGFloat kMenuImageSize ;
 
 extern NSString * const kRealmFileExtension;
+extern NSString * const kRealmUTIIdentifier;
 extern NSString * const kDeveloperFolder;
 extern NSString * const kSimulatorFolder;
 extern NSString * const kDesktopFolder;

--- a/RealmBrowser/Support/RLMBrowserConstants.m
+++ b/RealmBrowser/Support/RLMBrowserConstants.m
@@ -24,6 +24,7 @@ const CGFloat kMenuImageSize = 16;
 const NSInteger kMaxNumberOfFilesAtOnce = 20;
 
 NSString * const kRealmFileExtension    = @"realm";
+NSString * const kRealmUTIIdentifier    = @"io.realm.realm";
 NSString * const kDeveloperFolder       = @"/Developer";
 NSString * const kSimulatorFolder       = @"/Library/Application Support/iPhone Simulator";
 NSString * const kDesktopFolder         = @"/Desktop";


### PR DESCRIPTION
A very quick follow-up to @stel's UTI enhancement. :)

I'm not sure where the string `documenttype` was being defined previously, but it looks like the `RLMDocument` file type check needs the new UTI identifier string in its place, otherwise the Browser refuses to open Realm files.

I've made a note to create a test to ensure things like this get caught in future. :)