### PR TITLE
Java exporter: Better support for optional fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
+* Adding support for optional fields (Java exporter)
 
 0.103.1 Release notes (2016-05-20)
 =============================================================

--- a/RealmBrowser/Support/RLMModelExporter.m
+++ b/RealmBrowser/Support/RLMModelExporter.m
@@ -187,19 +187,19 @@
 {
     switch (property.type) {
         case RLMPropertyTypeBool:
-            return @"boolean";
+            return property.optional ? @"Boolean" : @"boolean";
         case RLMPropertyTypeInt:
-            return @"int";
+            return property.optional ? @"Long" : @"long";
         case RLMPropertyTypeFloat:
-            return @"float";
+            return property.optional ? @"Float" : @"float";
         case RLMPropertyTypeDouble:
-            return @"double";
+            return property.optional ? @"Double" : @"double";
         case RLMPropertyTypeString:
             return @"String";
         case RLMPropertyTypeData:
             return @"byte[]";
         case RLMPropertyTypeAny:
-            return @"Any";
+            return @"Any";  // FIXME: we don't support it
         case RLMPropertyTypeDate:
             return @"Date";
         case RLMPropertyTypeArray:


### PR DESCRIPTION
The Java binding is using boxed types for indicating nullability. 

@stk1m1 @TimOliver