### PR TITLE
Open common location fixes

### DIFF
--- a/RealmBrowser.xcodeproj/project.pbxproj
+++ b/RealmBrowser.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		84E35A49196AD991007F0344 /* RLMNavigationStack.m in Sources */ = {isa = PBXBuildFile; fileRef = 84E35A48196AD991007F0344 /* RLMNavigationStack.m */; };
 		84E35A4D196B021B007F0344 /* RLMArrayNavigationState.m in Sources */ = {isa = PBXBuildFile; fileRef = 84E35A4C196B021B007F0344 /* RLMArrayNavigationState.m */; };
 		ADBD77D758972C8C68C6F371 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		C299E3921D2E4ECF00D0DA91 /* RLMUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = C299E3911D2E4ECF00D0DA91 /* RLMUtils.m */; };
 		E84EB8201A2FB7F500EB780E /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 844C34DE19473D9D0027E902 /* libc++.dylib */; };
 		E84EB8291A2FC38C00EB780E /* RLMTestObjects.m in Sources */ = {isa = PBXBuildFile; fileRef = E84EB8281A2FC38C00EB780E /* RLMTestObjects.m */; };
 		F57853F0E9C240FD283A4F8C /* Pods_RealmBrowser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88A0814FC1FBF4B1C1E4D428 /* Pods_RealmBrowser.framework */; };
@@ -201,6 +202,8 @@
 		A4F4F093ABA4699B1D57AF0F /* Pods-RealmBrowser.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmBrowser.release.xcconfig"; path = "Pods/Target Support Files/Pods-RealmBrowser/Pods-RealmBrowser.release.xcconfig"; sourceTree = "<group>"; };
 		B4DD42CE427D384E8A7351A0 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5A5F0615B6ED1995CD3051A /* Pods-RealmBrowser.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmBrowser.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RealmBrowser/Pods-RealmBrowser.debug.xcconfig"; sourceTree = "<group>"; };
+		C299E3911D2E4ECF00D0DA91 /* RLMUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMUtils.m; sourceTree = "<group>"; };
+		C299E3931D2E4EF900D0DA91 /* RLMUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMUtils.h; sourceTree = "<group>"; };
 		E84EB8271A2FC38C00EB780E /* RLMTestObjects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMTestObjects.h; sourceTree = "<group>"; };
 		E84EB8281A2FC38C00EB780E /* RLMTestObjects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMTestObjects.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -328,6 +331,8 @@
 				220D382719B639D700F79496 /* RLMTestDataGenerator.m */,
 				844C34E1194859080027E902 /* TestClasses.h */,
 				844C34E2194859080027E902 /* TestClasses.m */,
+				C299E3931D2E4EF900D0DA91 /* RLMUtils.h */,
+				C299E3911D2E4ECF00D0DA91 /* RLMUtils.m */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -673,6 +678,7 @@
 				2249D9B219A62EBD00A31104 /* RLMTableColumn.m in Sources */,
 				220D382819B639D700F79496 /* RLMTestDataGenerator.m in Sources */,
 				84E35A42196A9F3B007F0344 /* RLMNavigationState.m in Sources */,
+				C299E3921D2E4ECF00D0DA91 /* RLMUtils.m in Sources */,
 				2250CB571CFEA23F007B6566 /* RLMOptionalBoolTableCellView.m in Sources */,
 				84D7990D19388E8900FC76A0 /* RLMRealmNode.m in Sources */,
 				2234B6711CF83FBA00EAFDF0 /* RLMBrowserConstants.m in Sources */,

--- a/RealmBrowser/Application/RLMApplicationDelegate.m
+++ b/RealmBrowser/Application/RLMApplicationDelegate.m
@@ -150,7 +150,7 @@
 
 -(void)updateMenu:(NSMenu *)menu withItems:(NSArray *)items indented:(BOOL)indented
 {
-    NSImage *image = [NSImage imageNamed:@"AppIcon"];
+    NSImage *image = [NSImage imageNamed:@"RealmFileIcon"];
     image.size = NSMakeSize(kMenuImageSize, kMenuImageSize);
     
     for (id item in items) {

--- a/RealmBrowser/Application/RLMApplicationDelegate.m
+++ b/RealmBrowser/Application/RLMApplicationDelegate.m
@@ -22,6 +22,7 @@
 #import "RLMBrowserConstants.h"
 #import "RLMApplicationDelegate.h"
 #import "RLMTestDataGenerator.h"
+#import "RLMUtils.h"
 #import "TestClasses.h"
 
 #import <AppSandboxFileAccess/AppSandboxFileAccess.h>
@@ -251,15 +252,7 @@
 
 -(void)updateFileItems
 {
-    NSString *homeDir = NSHomeDirectory();
-    
-    // NSHomeDirectory() returns path to app's container directory like /PATH_TO_HOME_DIRECTORY/Library/Containers/NUNDLE_IDENTIFIER/Data in sandboxed environment.
-    // So removing 4 last path components should give a real path to user's home directory (at least until this path isn't changed).
-    if ([homeDir containsString:[NSBundle mainBundle].bundleIdentifier]) {
-        for (NSInteger i = 0; i < 4; i++) {
-            homeDir = [homeDir stringByDeletingLastPathComponent];
-        }
-    }
+    NSString *homeDir = RLMRealHomeDirectory();
     
     NSString *kPrefix = @"Prefix";
     NSString *kItems = @"Items";

--- a/RealmBrowser/Application/RLMApplicationDelegate.m
+++ b/RealmBrowser/Application/RLMApplicationDelegate.m
@@ -283,12 +283,12 @@
     NSDictionary *otherDict = @{kPrefix : allPrefix, kItems : [NSMutableArray arrayWithObject:@"Other"]};
     
     // Create array of dictionaries, each corresponding to search folders
-    self.groupedFileItems = @[simDict, devDict, desktopDict, documentsdDict, downloadDict, otherDict];
+    NSArray *tempGroupedFileItems = @[simDict, devDict, desktopDict, documentsdDict, downloadDict, otherDict];
     
     // Iterate through all search results
     for (NSMetadataItem *fileItem in self.realmQuery.results) {
         // Iterate through the different prefixes and add item to corresponding array within dictionary
-        for (NSDictionary *dict in self.groupedFileItems) {
+        for (NSDictionary *dict in tempGroupedFileItems) {
             if ([[fileItem valueForAttribute:NSMetadataItemPathKey] hasPrefix:dict[kPrefix]]) {
                 NSMutableArray *items = dict[kItems];
                 // The first few items are just added
@@ -310,6 +310,9 @@
             }
         }
     }
+    
+    // Do not include empty groups
+    self.groupedFileItems = [tempGroupedFileItems filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"%K.@count > 1", kItems]];
 }
 
 - (IBAction)generatedDemoDatabase:(id)sender

--- a/RealmBrowser/Application/RLMApplicationDelegate.m
+++ b/RealmBrowser/Application/RLMApplicationDelegate.m
@@ -253,6 +253,14 @@
 {
     NSString *homeDir = NSHomeDirectory();
     
+    // NSHomeDirectory() returns path to app's container directory like /PATH_TO_HOME_DIRECTORY/Library/Containers/NUNDLE_IDENTIFIER/Data in sandboxed environment.
+    // So removing 4 last path components should give a real path to user's home directory (at least until this path isn't changed).
+    if ([homeDir containsString:[NSBundle mainBundle].bundleIdentifier]) {
+        for (NSInteger i = 0; i < 4; i++) {
+            homeDir = [homeDir stringByDeletingLastPathComponent];
+        }
+    }
+    
     NSString *kPrefix = @"Prefix";
     NSString *kItems = @"Items";
     

--- a/RealmBrowser/Support/RLMBrowserConstants.m
+++ b/RealmBrowser/Support/RLMBrowserConstants.m
@@ -26,7 +26,7 @@ const CGFloat       kNilItemColor[] = {0.0f, 0.0f, 0.0f, 0.3f};
 
 NSString * const kRealmFileExtension    = @"realm";
 NSString * const kRealmUTIIdentifier    = @"io.realm.realm";
-NSString * const kDeveloperFolder       = @"/Developer";
+NSString * const kDeveloperFolder       = @"/Library/Developer";
 NSString * const kSimulatorFolder       = @"/Library/Application Support/iPhone Simulator";
 NSString * const kDesktopFolder         = @"/Desktop";
 NSString * const kDownloadFolder        = @"/Download";

--- a/RealmBrowser/Support/RLMUtils.h
+++ b/RealmBrowser/Support/RLMUtils.h
@@ -1,0 +1,21 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2014-2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+NSString *RLMRealHomeDirectory();

--- a/RealmBrowser/Support/RLMUtils.m
+++ b/RealmBrowser/Support/RLMUtils.m
@@ -1,0 +1,25 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2014-2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "RLMUtils.h"
+#include <pwd.h>
+
+NSString *RLMRealHomeDirectory() {
+    struct passwd *pw = getpwuid(getuid());
+    return @(pw->pw_dir);
+}


### PR DESCRIPTION
In sandboxed environment `NSHomeDirectory()` returns path to the app's container directory, not the real user home directory. That's why all found Realm files were displayed in "Other" group of the Open Common Location menu.

This PR also hides empty groups from the menu.

Closes #148.

/cc @TimOliver 