### PR TITLE
Remove explicit table view inserts/deletes/moves

### DIFF
--- a/RealmBrowser/Controllers/RLMInstanceTableViewController.h
+++ b/RealmBrowser/Controllers/RLMInstanceTableViewController.h
@@ -35,7 +35,6 @@
 
 - (void)removeRowsInTableViewAt:(NSIndexSet *)rowIndexes;
 - (void)deleteRowsInTableViewAt:(NSIndexSet *)rowIndexes;
-- (void)insertNewRowsInTableViewAt:(NSIndexSet *)rowIndexes;
 - (void)moveRowsInTableViewFrom:(NSIndexSet *)sourceIndexes to:(NSUInteger)destination;
 
 @end

--- a/RealmBrowser/Controllers/RLMInstanceTableViewController.h
+++ b/RealmBrowser/Controllers/RLMInstanceTableViewController.h
@@ -33,8 +33,4 @@
 
 @property (nonatomic, copy) void(^didSelectedBlock)(RLMObject *rowObject);
 
-- (void)removeRowsInTableViewAt:(NSIndexSet *)rowIndexes;
-- (void)deleteRowsInTableViewAt:(NSIndexSet *)rowIndexes;
-- (void)moveRowsInTableViewFrom:(NSIndexSet *)sourceIndexes to:(NSUInteger)destination;
-
 @end

--- a/RealmBrowser/Controllers/RLMInstanceTableViewController.m
+++ b/RealmBrowser/Controllers/RLMInstanceTableViewController.m
@@ -516,13 +516,11 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 - (void)removeRows:(NSIndexSet *)rowIndexes
 {
     [self removeRowsInRealmAt:rowIndexes];
-    [self.parentWindowController removeRowsInTableViewForArrayNode:(RLMArrayNode *)self.displayedType at:rowIndexes];
 }
 
 - (void)deleteRows:(NSIndexSet *)rowIndexes
 {
     [self deleteRowsInRealmAt:rowIndexes];
-    [self.parentWindowController deleteRowsInTableViewForArrayNode:(RLMArrayNode *)self.displayedType at:rowIndexes];
 }
 
 - (void)addNewRows:(NSIndexSet *)rowIndexes

--- a/RealmBrowser/Controllers/RLMInstanceTableViewController.m
+++ b/RealmBrowser/Controllers/RLMInstanceTableViewController.m
@@ -528,7 +528,6 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 - (void)addNewRows:(NSIndexSet *)rowIndexes
 {
     [self insertNewRowsInRealmAt:rowIndexes];
-    [self.parentWindowController insertNewRowsInTableViewForArrayNode:(RLMArrayNode *)self.displayedType at:rowIndexes];
 }
 
 // Operations on links in cells
@@ -786,23 +785,6 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     }];
     
     [realm commitWriteTransaction];
-}
-
-- (void)insertNewRowsInTableViewAt:(NSIndexSet *)rowIndexes
-{
-    if (rowIndexes.count == 0) {
-        rowIndexes = [NSIndexSet indexSetWithIndex:0];
-    }
-    
-    [self.tableView beginUpdates];
-    
-    [rowIndexes enumerateRangesWithOptions:NSEnumerationReverse usingBlock:^(NSRange range, BOOL *stop) {
-        NSIndexSet *indexSetForRange = [NSIndexSet indexSetWithIndexesInRange:range];
-        [self.tableView insertRowsAtIndexes:indexSetForRange withAnimation:NSTableViewAnimationEffectGap];
-    }];
-    
-    [self.tableView endUpdates];
-    [self updateArrayIndexColumn];
 }
 
 // Moving

--- a/RealmBrowser/Controllers/RLMInstanceTableViewController.m
+++ b/RealmBrowser/Controllers/RLMInstanceTableViewController.m
@@ -205,9 +205,6 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
         
         // Performs the move in the realm
         [self moveRowsInRealmFrom:rowIndexes to:destination];
-
-        // Performs the move visually in all relevant windows
-        [self.parentWindowController moveRowsInTableViewForArrayNode:(RLMArrayNode *)self.displayedType from:rowIndexes to:destination];
         
         return YES;
     }
@@ -736,7 +733,6 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 
 #pragma mark - Rearranging objects in arrays - Private methods
 
-// Removing
 - (void)removeRowsInRealmAt:(NSIndexSet *)rowIndexes
 {
     RLMRealm *realm = self.parentWindowController.document.presentedRealm.realm;
@@ -748,23 +744,11 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     [realm commitWriteTransaction];
 }
 
-- (void)removeRowsInTableViewAt:(NSIndexSet *)rowIndexes
-{
-    [self removeRowsInTableViewAtIndexes:rowIndexes];
-}
-
-// Deleting
 - (void)deleteRowsInRealmAt:(NSIndexSet *)rowIndexes
 {
     [self deleteObjectsInRealmAtIndexes:rowIndexes];
 }
 
-- (void)deleteRowsInTableViewAt:(NSIndexSet *)rowIndexes
-{
-    [self removeRowsInTableViewAtIndexes:rowIndexes];
-}
-
-// Inserting
 - (void)insertNewRowsInRealmAt:(NSIndexSet *)rowIndexes
 {
     if (rowIndexes.count == 0) {
@@ -785,7 +769,6 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     [realm commitWriteTransaction];
 }
 
-// Moving
 - (void)moveRowsInRealmFrom:(NSIndexSet *)sourceIndexes to:(NSUInteger)destination
 {
     RLMRealm *realm = self.parentWindowController.document.presentedRealm.realm;
@@ -806,44 +789,6 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     [realm commitWriteTransaction];
 }
 
-- (void)moveRowsInTableViewFrom:(NSIndexSet *)sourceIndexes to:(NSUInteger)destination
-{
-    NSMutableArray *sources = [self arrayWithIndexSet:sourceIndexes];
-    
-    [self.tableView beginUpdates];
-    
-    // Iterate through the array, representing source row indices
-    for (NSUInteger i = 0; i < sources.count; i++) {
-        NSUInteger source = [sources[i] unsignedIntegerValue];
-        
-        NSInteger tableViewDestination = destination > source ? destination - 1 : destination;
-        [self.tableView moveRowAtIndex:source toIndex:tableViewDestination];
-
-        [self updateSourceIndices:sources afterIndex:i withSource:source destination:&destination];
-    }
-    
-    [self.tableView endUpdates];
-    [self updateArrayIndexColumn];
-}
-
-#pragma mark - Rearranging objects - Helper methods
-
-// Updates the index column in arrays after rearranging rows
--(void)updateArrayIndexColumn
-{
-    for (NSUInteger k = 0; k < self.tableView.numberOfRows; k++) {
-        NSTableRowView *rowView = [self.tableView rowViewAtRow:k makeIfNecessary:NO];
-        RLMTableCellView *cell = [rowView viewAtColumn:0];
-        cell.textField.stringValue = [@(k) stringValue];
-    }
-}
-
-- (void)removeRowsInTableViewAtIndexes:(NSIndexSet *)rowIndexes
-{
-    [self.tableView deselectAll:self];
-    [self.tableView removeRowsAtIndexes:rowIndexes withAnimation:NSTableViewAnimationEffectGap];
-    [self updateArrayIndexColumn];
-}
 
 - (void)deleteObjectsInRealmAtIndexes:(NSIndexSet *)rowIndexes
 {

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.h
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.h
@@ -37,8 +37,6 @@ extern const NSUInteger kMaxNumberOfArrayEntriesInToolTip;
 
 - (void)deleteRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode at:(NSIndexSet *)rowIndexes;
 
-- (void)insertNewRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode at:(NSIndexSet *)rowIndexes;
-
 - (void)moveRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode from:(NSIndexSet *)sourceIndexes to:(NSUInteger)destination;
 
 

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.h
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.h
@@ -33,9 +33,6 @@ extern const NSUInteger kMaxNumberOfArrayEntriesInToolTip;
 @property (nonatomic, strong) IBOutlet RLMTypeOutlineViewController *outlineViewController;
 @property (nonatomic, strong) IBOutlet RLMInstanceTableViewController *tableViewController;
 
-- (void)moveRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode from:(NSIndexSet *)sourceIndexes to:(NSUInteger)destination;
-
-
 - (void)addNavigationState:(RLMNavigationState *)state fromViewController:(RLMViewController *)controller;
 
 - (void)newWindowWithNavigationState:(RLMNavigationState *)state;

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.h
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.h
@@ -33,10 +33,6 @@ extern const NSUInteger kMaxNumberOfArrayEntriesInToolTip;
 @property (nonatomic, strong) IBOutlet RLMTypeOutlineViewController *outlineViewController;
 @property (nonatomic, strong) IBOutlet RLMInstanceTableViewController *tableViewController;
 
-- (void)removeRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode at:(NSIndexSet *)rowIndexes;
-
-- (void)deleteRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode at:(NSIndexSet *)rowIndexes;
-
 - (void)moveRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode from:(NSIndexSet *)sourceIndexes to:(NSUInteger)destination;
 
 

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -462,29 +462,6 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
 
 #pragma mark - Public methods - Rearranging arrays
 
-- (void)removeRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode at:(NSIndexSet *)rowIndexes
-{
-    for (RLMRealmBrowserWindowController *wc in [self.document windowControllers]) {
-        if ([arrayNode isEqualTo:wc.tableViewController.displayedType]) {
-            [wc.tableViewController removeRowsInTableViewAt:rowIndexes];
-        }
-        [wc.outlineViewController.tableView reloadData];
-    }
-}
-
-- (void)deleteRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode at:(NSIndexSet *)rowIndexes
-{
-    for (RLMRealmBrowserWindowController *wc in [self.document windowControllers]) {
-        if ([arrayNode isEqualTo:wc.tableViewController.displayedType]) {
-            [wc.tableViewController deleteRowsInTableViewAt:rowIndexes];
-        }
-        else {
-            [wc reloadAfterEdit];
-        }
-        [wc.outlineViewController.tableView reloadData];
-    }
-}
-
 - (void)moveRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode from:(NSIndexSet *)sourceIndexes to:(NSUInteger)destination
 {
     for (RLMRealmBrowserWindowController *wc in [self.document windowControllers]) {

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -460,17 +460,6 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
     [self.tableViewController.tableView reloadData];
 }
 
-#pragma mark - Public methods - Rearranging arrays
-
-- (void)moveRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode from:(NSIndexSet *)sourceIndexes to:(NSUInteger)destination
-{
-    for (RLMRealmBrowserWindowController *wc in [self.document windowControllers]) {
-        if ([arrayNode isEqualTo:wc.tableViewController.displayedType]) {
-            [wc.tableViewController moveRowsInTableViewFrom:sourceIndexes to:destination];
-        }
-    }
-}
-
 #pragma mark - Public methods - Navigation
 
 - (void)addNavigationState:(RLMNavigationState *)state fromViewController:(RLMViewController *)controller

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -485,19 +485,6 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
     }
 }
 
-- (void)insertNewRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode at:(NSIndexSet *)rowIndexes
-{
-    for (RLMRealmBrowserWindowController *wc in [self.document windowControllers]) {
-        if ([arrayNode isEqualTo:wc.tableViewController.displayedType]) {
-            [wc.tableViewController insertNewRowsInTableViewAt:rowIndexes];
-        }
-        else {
-            [wc reloadAfterEdit];
-        }
-        [wc.outlineViewController.tableView reloadData];
-    }
-}
-
 - (void)moveRowsInTableViewForArrayNode:(RLMArrayNode *)arrayNode from:(NSIndexSet *)sourceIndexes to:(NSUInteger)destination
 {
     for (RLMRealmBrowserWindowController *wc in [self.document windowControllers]) {

--- a/RealmBrowser/Models/RLMArrayNode.m
+++ b/RealmBrowser/Models/RLMArrayNode.m
@@ -46,7 +46,7 @@
 
 -(BOOL)insertInstance:(RLMObject *)object atIndex:(NSUInteger)index
 {
-    if (index >= [displayedArray count] || !object) {
+    if (index > displayedArray.count || object == nil) {
         return NO;
     }
     

--- a/RealmBrowser/Views/RLMTableView.m
+++ b/RealmBrowser/Views/RLMTableView.m
@@ -360,7 +360,9 @@ const NSInteger NOT_A_COLUMN = -1;
 - (IBAction)addRowsToArrayAction:(id)sender
 {
     if (self.realmDelegate.displaysArray && !self.realmDelegate.realmIsLocked) {
-        [self.realmDelegate addNewRows:self.selectedRowIndexes];
+        NSInteger index = self.selectedRowIndexes.count > 0 ? self.selectedRowIndexes.lastIndex + 1 : self.numberOfRows;
+
+        [self.realmDelegate addNewRows:[NSIndexSet indexSetWithIndex:index]];
     }
 }
 


### PR DESCRIPTION
When objects are deleted/inserted into realm or moved/removed from list `RLMInstanceTableViewController` reloads table view because of realm's change notification, so it doesn't make any sense to update tableview rows directly and it also leads to a crash when adding/removing items in lists.

Also fixes #130 

@TimOliver, @jpsim how does it look to you?