### PR TITLE
Integrate HockeyApp crash reporting

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,6 +7,7 @@ target 'RealmBrowser' do
     pod 'AppSandboxFileAccess'
     pod 'Realm'
     pod 'RealmConverter'
+    pod 'HockeySDK-Mac'
 
     target 'RealmBrowserTests' do
       # It looks like that inheritance via search paths is still broken with frameworks, see https://github.com/CocoaPods/CocoaPods/issues/4944

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,7 @@
 PODS:
   - AppSandboxFileAccess (1.0.14)
   - CSwiftV (0.0.5)
+  - HockeySDK-Mac (4.1.0)
   - PathKit (0.6.0)
   - Realm (2.0.2):
     - Realm/Headers (= 2.0.2)
@@ -16,18 +17,20 @@ PODS:
 
 DEPENDENCIES:
   - AppSandboxFileAccess
+  - HockeySDK-Mac
   - Realm
   - RealmConverter
 
 SPEC CHECKSUMS:
   AppSandboxFileAccess: f3e10b0ba10bbaa6dc6996639ff47836050329c5
   CSwiftV: 2560532e2e5b04d95c36b0f49a8dc745071fa525
+  HockeySDK-Mac: c849a264e4f5f43520f7eec7d3f8b921cfc6e63b
   PathKit: b224b6d2c4e75b87f08f45e1c0c610a3195c94e5
   Realm: 0f5a194af0b7e6158b83db41b4ee1a00be7ddf1a
   RealmConverter: 816ad9621bdd59702bc2825abbcc8cc77e2997b3
   SSZipArchive: 428eb1ac8d37dd133404d30f422b23958c1f9acc
   TGSpreadsheetWriter: '09bbb2c18a111a11c94ff9c1af2320e2530c958e'
 
-PODFILE CHECKSUM: e5a61bcdd49785d0661d195d7800bcb81fc32e8c
+PODFILE CHECKSUM: 9ba80cdf314e7a2c4e1ea544b4b89d260dd0ed79
 
 COCOAPODS: 1.1.0.rc.2

--- a/RealmBrowser.xcodeproj/project.pbxproj
+++ b/RealmBrowser.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		C2AA0F631D634FBF00D5D7E6 /* RLMOpenSyncURLWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C2AA0F621D634FBF00D5D7E6 /* RLMOpenSyncURLWindowController.m */; };
 		C2AA0F671D634FDA00D5D7E6 /* RLMConnectToServerWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C2AA0F651D634FDA00D5D7E6 /* RLMConnectToServerWindowController.m */; };
 		C2B7CAC01D11A0C900049C32 /* ConnectToServerWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = C2B7CABF1D11A0C900049C32 /* ConnectToServerWindow.xib */; };
+		C2CA58F01DAE3B6B0052BAAA /* RLMApplicationDelegate+CrashReporting.m in Sources */ = {isa = PBXBuildFile; fileRef = C2CA58EF1DAE3B6B0052BAAA /* RLMApplicationDelegate+CrashReporting.m */; };
 		C2D302DC1D6DF63700E091DF /* RLMDocumentController.m in Sources */ = {isa = PBXBuildFile; fileRef = C2D302DB1D6DF63700E091DF /* RLMDocumentController.m */; };
 		C2D302E41D74528800E091DF /* RLMCredentialsWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C2D302E31D74528800E091DF /* RLMCredentialsWindowController.m */; };
 		C2D302E61D7455B600E091DF /* CredentialsWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = C2D302E51D7455B600E091DF /* CredentialsWindow.xib */; };
@@ -249,6 +250,8 @@
 		C2AA0F641D634FDA00D5D7E6 /* RLMConnectToServerWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMConnectToServerWindowController.h; sourceTree = "<group>"; };
 		C2AA0F651D634FDA00D5D7E6 /* RLMConnectToServerWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMConnectToServerWindowController.m; sourceTree = "<group>"; };
 		C2B7CABF1D11A0C900049C32 /* ConnectToServerWindow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ConnectToServerWindow.xib; sourceTree = "<group>"; };
+		C2CA58EE1DAE3B6B0052BAAA /* RLMApplicationDelegate+CrashReporting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RLMApplicationDelegate+CrashReporting.h"; sourceTree = "<group>"; };
+		C2CA58EF1DAE3B6B0052BAAA /* RLMApplicationDelegate+CrashReporting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RLMApplicationDelegate+CrashReporting.m"; sourceTree = "<group>"; };
 		C2D302DA1D6DF63700E091DF /* RLMDocumentController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMDocumentController.h; sourceTree = "<group>"; };
 		C2D302DB1D6DF63700E091DF /* RLMDocumentController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMDocumentController.m; sourceTree = "<group>"; };
 		C2D302E21D74528800E091DF /* RLMCredentialsWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMCredentialsWindowController.h; sourceTree = "<group>"; };
@@ -499,6 +502,8 @@
 			children = (
 				84A34A4D192E19C5005D6CC4 /* RLMApplicationDelegate.h */,
 				84A34A4E192E19C5005D6CC4 /* RLMApplicationDelegate.m */,
+				C2CA58EE1DAE3B6B0052BAAA /* RLMApplicationDelegate+CrashReporting.h */,
+				C2CA58EF1DAE3B6B0052BAAA /* RLMApplicationDelegate+CrashReporting.m */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -860,6 +865,7 @@
 				844C34E3194859080027E902 /* TestClasses.m in Sources */,
 				C29CC7B61D76D4E300186B29 /* RLMCredentialViewController.m in Sources */,
 				C27721DA1D92D6CA00DEBF75 /* RLMCloudKitCredentialViewController.m in Sources */,
+				C2CA58F01DAE3B6B0052BAAA /* RLMApplicationDelegate+CrashReporting.m in Sources */,
 				84E35A4D196B021B007F0344 /* RLMArrayNavigationState.m in Sources */,
 				C2D302EE1D75A2E100E091DF /* RLMWindowController.m in Sources */,
 				84446534195891AA00CEEA5B /* RLMViewController.m in Sources */,

--- a/RealmBrowser/Application/RLMApplicationDelegate+CrashReporting.h
+++ b/RealmBrowser/Application/RLMApplicationDelegate+CrashReporting.h
@@ -1,0 +1,25 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2014-2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "RLMApplicationDelegate.h"
+
+@interface RLMApplicationDelegate (CrashReporting)
+
+- (void)setupCrashReporting;
+
+@end

--- a/RealmBrowser/Application/RLMApplicationDelegate+CrashReporting.m
+++ b/RealmBrowser/Application/RLMApplicationDelegate+CrashReporting.m
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2014-2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+@import HockeySDK;
+
+#import "RLMApplicationDelegate+CrashReporting.h"
+
+static NSString * const RLMHockeyAppIdentifier = @"ca846ff98222427fa286a4bc76bc7533";
+
+@implementation RLMApplicationDelegate (CrashReporting)
+
+- (void)setupCrashReporting {
+    BITHockeyManager *manager = [BITHockeyManager sharedHockeyManager];
+
+    [manager configureWithIdentifier:RLMHockeyAppIdentifier];
+    [manager startManager];
+}
+
+@end

--- a/RealmBrowser/Application/RLMApplicationDelegate.m
+++ b/RealmBrowser/Application/RLMApplicationDelegate.m
@@ -21,8 +21,10 @@
 @import RealmConverter;
 @import AppSandboxFileAccess;
 
-#import "RLMBrowserConstants.h"
 #import "RLMApplicationDelegate.h"
+#import "RLMApplicationDelegate+CrashReporting.h"
+
+#import "RLMBrowserConstants.h"
 #import "RLMDocumentController.h"
 
 #import "RLMTestDataGenerator.h"
@@ -71,6 +73,8 @@
 
 -(void)applicationDidFinishLaunching:(NSNotification *)notification
 {
+    [self setupCrashReporting];
+
     [[NSUserDefaults standardUserDefaults] setObject:@(kTopTipDelay) forKey:@"NSInitialToolTipDelay"];
     [[NSUserDefaults standardUserDefaults] synchronize];
 

--- a/RealmBrowser/Supporting Files/RealmBrowser-Info.plist
+++ b/RealmBrowser/Supporting Files/RealmBrowser-Info.plist
@@ -80,7 +80,7 @@
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
+	<string>BITCrashExceptionApplication</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This PR adds HockeyApp integration, see more at [Client Integration (iOS, Mac OS X & tvOS)](https://support.hockeyapp.net/kb/client-integration-ios-mac-os-x-tvos/hockeyapp-for-mac-os-x).

HockeyApp will be also configured to create GitHub issues for any reported crashes.

fixes #221 

/cc @jpsim, @TimOliver 