### PR TITLE
Fix export to Compacted Realm for sync URLs

### DIFF
--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -29,6 +29,7 @@
 #import "RLMEncryptionKeyWindowController.h"
 #import "RLMCredentialsWindowController.h"
 #import "RLMConnectionIndicatorWindowController.h"
+#import "RLMBrowserConstants.h"
 
 NSString * const kRealmLockedImage = @"RealmLocked";
 NSString * const kRealmUnlockedImage = @"RealmUnlocked";
@@ -319,7 +320,12 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
 
 - (IBAction)saveCopy:(id)sender
 {
-    NSString *fileName = [self.document.fileURL.path lastPathComponent];
+    NSString *fileName = self.document.fileURL.lastPathComponent ?: self.document.syncURL.lastPathComponent ?: @"Compacted";
+
+    if (![fileName.pathExtension isEqualToString:kRealmFileExtension]) {
+        fileName = [fileName.stringByDeletingPathExtension stringByAppendingPathExtension:kRealmFileExtension];
+    }
+
     NSSavePanel *panel = [NSSavePanel savePanel];
     panel.canCreateDirectories = YES;
     panel.nameFieldStringValue = fileName;

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -318,7 +318,7 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
     [self saveModelsForLanguage:RLMModelExporterLanguageSwift];
 }
 
-- (IBAction)saveCopy:(id)sender
+- (IBAction)exportToCompactedRealm:(id)sender
 {
     NSString *fileName = self.document.fileURL.lastPathComponent ?: self.document.syncURL.lastPathComponent ?: @"Compacted";
 
@@ -330,16 +330,15 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
     panel.canCreateDirectories = YES;
     panel.nameFieldStringValue = fileName;
     [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result){
-        if (result != NSFileHandlingPanelOKButton)
+        if (result != NSFileHandlingPanelOKButton || !panel.URL) {
             return;
+        }
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            NSURL *fileURL = [panel URL];
-            
             AppSandboxFileAccess *fileAccess = [AppSandboxFileAccess fileAccess];
             [fileAccess requestAccessPermissionsForFileURL:panel.URL persistPermission:YES withBlock:^(NSURL *securelyScopedURL, NSData *bookmarkData) {
                 [securelyScopedURL startAccessingSecurityScopedResource];
-                [self exportAndCompactCopyOfRealmFileAtURL:fileURL];
+                [self exportAndCompactCopyOfRealmFileAtURL:panel.URL];
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [securelyScopedURL stopAccessingSecurityScopedResource];
                 }); 

--- a/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
+++ b/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G1004" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -163,10 +163,10 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Export To" id="KHC-xM-yfH">
                                     <items>
-                                        <menuItem title="Compressed Realm..." id="pNK-cr-EuG">
+                                        <menuItem title="Compacted Realm..." id="pNK-cr-EuG">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="saveCopy:" target="-1" id="o1I-h3-Hhd"/>
+                                                <action selector="exportToCompactedRealm:" target="-1" id="Bqf-SJ-Zgf"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="CSV..." id="r4f-YM-16u">


### PR DESCRIPTION
This PR fixes export to compacted realm file from sync realm URL and renames "Export to -> _Compressed_ Realm.." menu item to "Export to -> _Compacted_ Realm..".

/cc @TimOliver, @jpsim 