### PR TITLE
Release 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: objective-c
 osx_image: xcode8
 before_install:
 - gem uninstall cocoapods --all
-- gem install cocoapods --pre
+- gem install cocoapods
 - pod repo update --silent
 script: set -o pipefail && xcodebuild -workspace "RealmBrowser.xcworkspace" -scheme "Realm Browser" clean test | xcpretty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.1.0 Release notes (2016-10-28)
+=============================================================
+* Added in-app crash reporting
+* Added the ability to connect to Realm Object Server with admin username/password
+* Fixed export to Compacted Realm
+
 2.0.1 Release notes (2016-10-06)
 =============================================================
 This release introduces support for the Realm Mobile Platform!

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - Realm (2.0.3):
     - Realm/Headers (= 2.0.3)
   - Realm/Headers (2.0.3)
-  - RealmConverter (0.2.0):
+  - RealmConverter (0.2.1):
     - CSwiftV
     - PathKit (~> 0.6.0)
     - Realm
@@ -27,7 +27,7 @@ SPEC CHECKSUMS:
   HockeySDK-Mac: c849a264e4f5f43520f7eec7d3f8b921cfc6e63b
   PathKit: b224b6d2c4e75b87f08f45e1c0c610a3195c94e5
   Realm: 5f008bfe3c8c47142eddfc30b8c1584cde22db24
-  RealmConverter: 816ad9621bdd59702bc2825abbcc8cc77e2997b3
+  RealmConverter: 3a0ff752b3f699d64ad56a10d571471ccb3c7af3
   SSZipArchive: 428eb1ac8d37dd133404d30f422b23958c1f9acc
   TGSpreadsheetWriter: '09bbb2c18a111a11c94ff9c1af2320e2530c958e'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,9 +3,9 @@ PODS:
   - CSwiftV (0.0.5)
   - HockeySDK-Mac (4.1.0)
   - PathKit (0.6.0)
-  - Realm (2.0.2):
-    - Realm/Headers (= 2.0.2)
-  - Realm/Headers (2.0.2)
+  - Realm (2.0.3):
+    - Realm/Headers (= 2.0.3)
+  - Realm/Headers (2.0.3)
   - RealmConverter (0.2.0):
     - CSwiftV
     - PathKit (~> 0.6.0)
@@ -26,11 +26,11 @@ SPEC CHECKSUMS:
   CSwiftV: 2560532e2e5b04d95c36b0f49a8dc745071fa525
   HockeySDK-Mac: c849a264e4f5f43520f7eec7d3f8b921cfc6e63b
   PathKit: b224b6d2c4e75b87f08f45e1c0c610a3195c94e5
-  Realm: 0f5a194af0b7e6158b83db41b4ee1a00be7ddf1a
+  Realm: 5f008bfe3c8c47142eddfc30b8c1584cde22db24
   RealmConverter: 816ad9621bdd59702bc2825abbcc8cc77e2997b3
   SSZipArchive: 428eb1ac8d37dd133404d30f422b23958c1f9acc
   TGSpreadsheetWriter: '09bbb2c18a111a11c94ff9c1af2320e2530c958e'
 
 PODFILE CHECKSUM: 9ba80cdf314e7a2c4e1ea544b4b89d260dd0ed79
 
-COCOAPODS: 1.1.0.rc.2
+COCOAPODS: 1.1.1

--- a/RealmBrowser.xcodeproj/project.pbxproj
+++ b/RealmBrowser.xcodeproj/project.pbxproj
@@ -671,7 +671,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = RLM;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0810;
 				ORGANIZATIONNAME = "Realm inc.";
 				TargetAttributes = {
 					84E0F94B1921F3B900D6CA14 = {

--- a/RealmBrowser.xcodeproj/xcshareddata/xcschemes/Realm Browser.xcscheme
+++ b/RealmBrowser.xcodeproj/xcshareddata/xcschemes/Realm Browser.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/RealmBrowser/Supporting Files/RealmBrowser-Info.plist
+++ b/RealmBrowser/Supporting Files/RealmBrowser-Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -65,7 +65,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>79</string>
+	<string>80</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
This release is build with Xcode 8.1, includes Realm 2.0.3 and enables crash reporting.

We would probably need to release RealmConverter (with https://github.com/realm/realm-cocoa-converter/issues/26 fixed) and include a new version to this release as well as this fixes some import-related issues.

/cc @radu-tutueanu, @jpsim, @TimOliver 
