### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-2.1.0 Release notes (2016-11-23)
+2.1.0 Release notes (2016-11-24)
 =============================================================
 * Added in-app crash reporting
 * Added the ability to connect to Realm Object Server with admin username/password

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-2.1.0 Release notes (2016-10-28)
+2.1.0 Release notes (2016-11-23)
 =============================================================
 * Added in-app crash reporting
 * Added the ability to connect to Realm Object Server with admin username/password
+* Improved property type detection when import from CSV files
 * Fixed export to Compacted Realm
+* Fixed crash related to sync metadata reset
 
 2.0.1 Release notes (2016-10-06)
 =============================================================

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ use_frameworks!
 
 target 'RealmBrowser' do
     pod 'AppSandboxFileAccess'
-    pod 'Realm', git: 'https://github.com/realm/realm-cocoa.git', commit: '8606d5b42daf6eb9ad845bcbe0b7a1b8a46e665b', submodules: true
+    pod 'Realm', git: 'https://github.com/realm/realm-cocoa.git', commit: '293e3f3b09b2ed800dab6ee8138eb32de2224d5f', submodules: true
     pod 'RealmConverter'
     pod 'HockeySDK-Mac'
 

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ use_frameworks!
 
 target 'RealmBrowser' do
     pod 'AppSandboxFileAccess'
-    pod 'Realm'
+    pod 'Realm', git: 'https://github.com/realm/realm-cocoa.git', commit: '8606d5b42daf6eb9ad845bcbe0b7a1b8a46e665b', submodules: true
     pod 'RealmConverter'
     pod 'HockeySDK-Mac'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -18,8 +18,20 @@ PODS:
 DEPENDENCIES:
   - AppSandboxFileAccess
   - HockeySDK-Mac
-  - Realm
+  - Realm (from `https://github.com/realm/realm-cocoa.git`, commit `8606d5b42daf6eb9ad845bcbe0b7a1b8a46e665b`)
   - RealmConverter
+
+EXTERNAL SOURCES:
+  Realm:
+    :commit: 8606d5b42daf6eb9ad845bcbe0b7a1b8a46e665b
+    :git: https://github.com/realm/realm-cocoa.git
+    :submodules: true
+
+CHECKOUT OPTIONS:
+  Realm:
+    :commit: 8606d5b42daf6eb9ad845bcbe0b7a1b8a46e665b
+    :git: https://github.com/realm/realm-cocoa.git
+    :submodules: true
 
 SPEC CHECKSUMS:
   AppSandboxFileAccess: f3e10b0ba10bbaa6dc6996639ff47836050329c5
@@ -31,6 +43,6 @@ SPEC CHECKSUMS:
   SSZipArchive: 428eb1ac8d37dd133404d30f422b23958c1f9acc
   TGSpreadsheetWriter: '09bbb2c18a111a11c94ff9c1af2320e2530c958e'
 
-PODFILE CHECKSUM: 9ba80cdf314e7a2c4e1ea544b4b89d260dd0ed79
+PODFILE CHECKSUM: 3135190d298474ad4a703e5930593948e45bf00d
 
 COCOAPODS: 1.1.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -18,18 +18,18 @@ PODS:
 DEPENDENCIES:
   - AppSandboxFileAccess
   - HockeySDK-Mac
-  - Realm (from `https://github.com/realm/realm-cocoa.git`, commit `8606d5b42daf6eb9ad845bcbe0b7a1b8a46e665b`)
+  - Realm (from `https://github.com/realm/realm-cocoa.git`, commit `293e3f3b09b2ed800dab6ee8138eb32de2224d5f`)
   - RealmConverter
 
 EXTERNAL SOURCES:
   Realm:
-    :commit: 8606d5b42daf6eb9ad845bcbe0b7a1b8a46e665b
+    :commit: 293e3f3b09b2ed800dab6ee8138eb32de2224d5f
     :git: https://github.com/realm/realm-cocoa.git
     :submodules: true
 
 CHECKOUT OPTIONS:
   Realm:
-    :commit: 8606d5b42daf6eb9ad845bcbe0b7a1b8a46e665b
+    :commit: 293e3f3b09b2ed800dab6ee8138eb32de2224d5f
     :git: https://github.com/realm/realm-cocoa.git
     :submodules: true
 
@@ -43,6 +43,6 @@ SPEC CHECKSUMS:
   SSZipArchive: 428eb1ac8d37dd133404d30f422b23958c1f9acc
   TGSpreadsheetWriter: '09bbb2c18a111a11c94ff9c1af2320e2530c958e'
 
-PODFILE CHECKSUM: 3135190d298474ad4a703e5930593948e45bf00d
+PODFILE CHECKSUM: 5cddeda13e4d9ba8fb8c05ea716bd98bf8366513
 
 COCOAPODS: 1.1.1

--- a/RealmBrowser/Supporting Files/RealmBrowser-Info.plist
+++ b/RealmBrowser/Supporting Files/RealmBrowser-Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -65,7 +65,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>81</string>
+	<string>82</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/RealmBrowser/Supporting Files/RealmBrowser-Info.plist
+++ b/RealmBrowser/Supporting Files/RealmBrowser-Info.plist
@@ -65,7 +65,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>80</string>
+	<string>81</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/RealmBrowserSync/Controllers/RLMConnectToServerWindowController.m
+++ b/RealmBrowserSync/Controllers/RLMConnectToServerWindowController.m
@@ -92,7 +92,7 @@ NSString * const RLMConnectToServerWindowControllerErrorDomain = @"io.realm.real
 
 #pragma mark - RLMCredentialsViewControllerDelegate
 
-- (BOOL)credentialsViewController:(RLMCredentialsViewController *)controller shoudShowCredentialViewForIdentityProvider:(RLMIdentityProvider)provider {
+- (BOOL)credentialsViewController:(RLMCredentialsViewController *)controller shoudShowCredentialsViewForIdentityProvider:(RLMIdentityProvider)provider {
     return provider == RLMIdentityProviderAccessToken || provider == RLMIdentityProviderUsernamePassword;
 }
 


### PR DESCRIPTION
Updated to realm-cocoa with reset sync metadata enabled, fixes https://github.com/realm/realm-browser-osx/issues/228, will send for a review.