### PR TITLE
Disable editing values for primary key properties

### DIFF
--- a/RealmBrowser/Controllers/RLMInstanceTableViewController.m
+++ b/RealmBrowser/Controllers/RLMInstanceTableViewController.m
@@ -927,10 +927,15 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     }
     
     if (result || optionalValue) {
+        NSError *error;
         RLMRealm *realm = self.parentWindowController.document.presentedRealm.realm;
+
         [realm beginWriteTransaction];
         selectedInstance[propertyNode.name] = result;
-        [realm commitWriteTransaction];
+
+        if (![realm commitWriteTransaction:&error]) {
+            [NSApp presentError:error];
+        }
     }
     
     [self.parentWindowController reloadAllWindows];

--- a/RealmBrowser/Controllers/RLMInstanceTableViewController.m
+++ b/RealmBrowser/Controllers/RLMInstanceTableViewController.m
@@ -389,7 +389,7 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 
             numberCellView.optional = optional;
             numberCellView.textField.objectValue = propertyValue;            
-            numberCellView.textField.editable = !self.realmIsLocked;
+            numberCellView.textField.editable = !self.realmIsLocked && !classProperty.isPrimaryKey;
 
             cellView = numberCellView;
             
@@ -429,7 +429,7 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
             }
             basicCellView.optional = optional;
             basicCellView.textField.stringValue = [realmDescriptions printablePropertyValue:propertyValue ofType:type];
-            basicCellView.textField.editable = !self.realmIsLocked && type != RLMPropertyTypeData;
+            basicCellView.textField.editable = !self.realmIsLocked && type != RLMPropertyTypeData && !classProperty.isPrimaryKey;
 
             cellView = basicCellView;
             

--- a/RealmBrowser/Models/RLMClassProperty.h
+++ b/RealmBrowser/Models/RLMClassProperty.h
@@ -24,8 +24,9 @@
 @property (nonatomic, readonly) RLMProperty *property;
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) RLMPropertyType type;
+@property (nonatomic, readonly) BOOL isPrimaryKey;
 @property (nonatomic, readonly) Class class;
 
-- (instancetype)initWithProperty:(RLMProperty *)property;
+- (instancetype)initWithProperty:(RLMProperty *)property isPrimaryKey:(BOOL)flag;
 
 @end

--- a/RealmBrowser/Models/RLMClassProperty.m
+++ b/RealmBrowser/Models/RLMClassProperty.m
@@ -16,16 +16,16 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import "RLMClassProperty.h"
-
 #import "RLMClassNode.h"
+#import "RLMClassProperty.h"
 
 @implementation RLMClassProperty
 
-- (instancetype)initWithProperty:(RLMProperty *)property;
+- (instancetype)initWithProperty:(RLMProperty *)property isPrimaryKey:(BOOL)flag;
 {
     if (self = [super init]) {
         _property = property;
+        _isPrimaryKey = flag;
     }
     return self;
 }

--- a/RealmBrowser/Models/RLMTypeNode.m
+++ b/RealmBrowser/Models/RLMTypeNode.m
@@ -100,8 +100,9 @@
     
     NSMutableArray *result = [[NSMutableArray alloc] initWithCapacity:propertyCount];
     for (NSUInteger index = 0; index < propertyCount; index++) {
-        RLMProperty *property = properties[index];        
-        RLMClassProperty *tableColumn = [[RLMClassProperty alloc] initWithProperty:property];
+        RLMProperty *property = properties[index];
+        BOOL isPrimaryKey = [schema.primaryKeyProperty isEqualToProperty:property];
+        RLMClassProperty *tableColumn = [[RLMClassProperty alloc] initWithProperty:property isPrimaryKey:isPrimaryKey];
         [result addObject:tableColumn];
     }
     

--- a/RealmBrowser/Views/RLMTableView.m
+++ b/RealmBrowser/Views/RLMTableView.m
@@ -464,7 +464,7 @@ const NSInteger NOT_A_COLUMN = -1;
         RLMTableHeaderCell *headerCell = [[RLMTableHeaderCell alloc] init];
         headerCell.wraps = YES;
         headerCell.firstLine = propertyColumn.name;
-        headerCell.secondLine = [RLMDescriptions typeNameOfProperty:propertyColumn.property];
+        headerCell.secondLine = [NSString stringWithFormat:@"%@%@", [RLMDescriptions typeNameOfProperty:propertyColumn.property], propertyColumn.isPrimaryKey ? @", Primary Key" :@""];
         tableColumn.headerCell = headerCell;
         tableColumn.minWidth = 26.0;
         


### PR DESCRIPTION
From the Docs:
> Once an object with a primary key is added to a Realm, the primary key cannot be changed.

Primary key columns is now marked with "Primary Key" label.