### PR TITLE
Check if object still exists on end editing

### DIFF
--- a/RealmBrowser/Controllers/RLMInstanceTableViewController.m
+++ b/RealmBrowser/Controllers/RLMInstanceTableViewController.m
@@ -887,6 +887,12 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
 - (IBAction)editedTextField:(NSTextField *)sender {
     NSInteger row = [self.tableView rowForView:sender];
     NSInteger column = [self.tableView columnForView:sender];
+
+    if (row < 0 || column < 0) {
+        // Table view was reloaded during editing
+        return;
+    }
+
     NSInteger propertyIndex = [self propertyIndexForColumn:column];
 
     RLMTypeNode *displayedType = self.displayedType;


### PR DESCRIPTION
This PR prevents a crash when removed object is being edited while table view reloading.