### PR TITLE
Fix CSV export of synced realms and minor export fixes

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,10 +3,10 @@ PODS:
   - CSwiftV (0.0.5)
   - HockeySDK-Mac (4.1.2)
   - PathKit (0.6.0)
-  - Realm (2.1.1):
-    - Realm/Headers (= 2.1.1)
-  - Realm/Headers (2.1.1)
-  - RealmConverter (0.2.1):
+  - Realm (2.1.2):
+    - Realm/Headers (= 2.1.2)
+  - Realm/Headers (2.1.2)
+  - RealmConverter (0.3.0):
     - CSwiftV
     - PathKit (~> 0.6.0)
     - Realm
@@ -26,8 +26,8 @@ SPEC CHECKSUMS:
   CSwiftV: 2560532e2e5b04d95c36b0f49a8dc745071fa525
   HockeySDK-Mac: f067286d489181dd3c43c14395a6570f3caf4704
   PathKit: b224b6d2c4e75b87f08f45e1c0c610a3195c94e5
-  Realm: a55959c0b171a5fe5267406d17f314fec3cefaae
-  RealmConverter: 3a0ff752b3f699d64ad56a10d571471ccb3c7af3
+  Realm: efe855f4d977c8ce5a82d3116d9f1ff155a6550c
+  RealmConverter: 3e334cc0d65f9016b9de5be59a818d72a6ed64ca
   SSZipArchive: 428eb1ac8d37dd133404d30f422b23958c1f9acc
   TGSpreadsheetWriter: '09bbb2c18a111a11c94ff9c1af2320e2530c958e'
 

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -41,10 +41,6 @@ NSString * const kRealmKeyOutlineWidthForRealm = @"OutlineWidthForRealm:%@";
 
 static void const *kWaitForDocumentSchemaLoadObservationContext;
 
-@interface RLMRealm ()
-- (BOOL)compact;
-@end
-
 @interface RLMRealmBrowserWindowController()<NSWindowDelegate>
 
 @property (atomic, weak) IBOutlet NSSplitView *splitView;
@@ -373,8 +369,6 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
 
 - (void)exportAndCompactCopyOfRealmFileAtURL:(NSURL *)realmFileURL
 {
-    NSError *error = nil;
-    
     //Check that this won't end up overwriting the original file
     if ([realmFileURL.path.lowercaseString isEqualToString:self.document.fileURL.path.lowercaseString]) {
         NSAlert *alert = [[NSAlert alloc] init];
@@ -386,9 +380,9 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
     
     //Ensure a file with the same name doesn't already exist
     BOOL directory = NO;
-    
     if ([[NSFileManager defaultManager] fileExistsAtPath:realmFileURL.path isDirectory:&directory] && !directory) {
-        if (![[NSFileManager defaultManager] removeItemAtPath:realmFileURL.path error:&error]) {
+        NSError *error = nil;
+        if (![[NSFileManager defaultManager] removeItemAtURL:realmFileURL error:&error]) {
             [NSApp presentError:error];
             return;
         }
@@ -422,18 +416,6 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
             closeExportWindowOnMainThreadAndShowError(error);
             return;
         }
-
-        RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
-        configuration.fileURL = realmFileURL;
-        configuration.dynamic = YES;
-        
-        RLMRealm *exportedRealm = [RLMRealm realmWithConfiguration:configuration error:&error];
-        if (exportedRealm == nil) {
-            closeExportWindowOnMainThreadAndShowError(error);
-            return;
-        }
-
-        [exportedRealm compact];
 
         closeExportWindowOnMainThreadAndShowError(nil);
     });

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -394,6 +394,8 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
 
             if (error != nil) {
                 [NSApp presentError:error];
+            } else {
+                [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:@[realmFileURL]];
             }
         });
     };

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -365,15 +365,19 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
         AppSandboxFileAccess *fileAccess = [AppSandboxFileAccess fileAccess];
         [fileAccess requestAccessPermissionsForFileURL:panel.URL persistPermission:YES withBlock:^(NSURL *securelyScopedURL, NSData *bookmarkData) {
             [securelyScopedURL startAccessingSecurityScopedResource];
-            
-            NSString *folderPath = panel.URL.path;
-            NSString *realmFolderPath = self.document.fileURL.path;
-            RLMCSVDataExporter *exporter = [[RLMCSVDataExporter alloc] initWithRealmFileAtPath:realmFolderPath];
+
+            RLMCSVDataExporter *exporter = [[RLMCSVDataExporter alloc] initWithRealm:self.document.presentedRealm.realm];
+
             NSError *error = nil;
+            NSString *folderPath = panel.URL.path;
             [exporter exportToFolderAtPath:folderPath withError:&error];
             
             dispatch_async(dispatch_get_main_queue(), ^{
                 [securelyScopedURL stopAccessingSecurityScopedResource];
+
+                if (error != nil) {
+                    [NSApp presentError:error];
+                }
             });
         }];
     }];

--- a/RealmBrowserSync/Controllers/RLMCloudKitCredentialViewController.m
+++ b/RealmBrowserSync/Controllers/RLMCloudKitCredentialViewController.m
@@ -39,7 +39,7 @@
     NSString *token = self.tokenTextField.stringValue;
 
     if (token.length > 0) {
-        return [[RLMSyncCredentials alloc] initWithCustomToken:token provider:RLMIdentityProviderICloud userInfo:nil];
+        return [[RLMSyncCredentials alloc] initWithCustomToken:token provider:RLMIdentityProviderCloudKit userInfo:nil];
     }
 
     return nil;

--- a/RealmBrowserSync/Controllers/RLMCredentialsViewController.m
+++ b/RealmBrowserSync/Controllers/RLMCredentialsViewController.m
@@ -39,7 +39,7 @@ RLMIdentityProvider const RLMIdentityProviderAccessToken = @"accessToken";
         RLMIdentityProviderUsernamePassword,
         RLMIdentityProviderFacebook,
         RLMIdentityProviderGoogle,
-        RLMIdentityProviderICloud,
+        RLMIdentityProviderCloudKit,
         @"accessToken"
     ];
 }
@@ -49,7 +49,7 @@ RLMIdentityProvider const RLMIdentityProviderAccessToken = @"accessToken";
         RLMIdentityProviderUsernamePassword: [RLMUsernameCredentialViewController class],
         RLMIdentityProviderFacebook: [RLMFacebookCredentialViewController class],
         RLMIdentityProviderGoogle: [RLMGoogleCredentialViewController class],
-        RLMIdentityProviderICloud: [RLMCloudKitCredentialViewController class],
+        RLMIdentityProviderCloudKit: [RLMCloudKitCredentialViewController class],
         @"accessToken": [RLMAccessTokenCredentialViewController class],
     };
 


### PR DESCRIPTION
This PR uses an updated version of RealmConverter and allows synced Realms to be exported to CSV properly.

`requestAccessPermissions` calls have been removed because `NSOpenPanel` grants permissions to selected directories.

Fixes #254 

/cc @jpsim, @TimOliver 