### PR TITLE
Skip sidebar selection handling on reload

### DIFF
--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -461,9 +461,7 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
 
 - (void)reloadAfterEdit
 {
-    NSInteger row = self.outlineViewController.tableView.selectedRow;
-    [self.outlineViewController.tableView reloadData];
-    [self.outlineViewController.tableView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
+    [self.outlineViewController reloadData];
     
     NSString *realmPath = self.document.fileURL.path;
     NSString *key = [NSString stringWithFormat:kRealmKeyIsLockedForRealm, realmPath];

--- a/RealmBrowser/Controllers/RLMTypeOutlineViewController.h
+++ b/RealmBrowser/Controllers/RLMTypeOutlineViewController.h
@@ -23,4 +23,6 @@
 
 @interface RLMTypeOutlineViewController : RLMViewController <NSOutlineViewDataSource, NSOutlineViewDelegate>
 
+- (void)reloadData;
+
 @end

--- a/RealmBrowser/Controllers/RLMTypeOutlineViewController.m
+++ b/RealmBrowser/Controllers/RLMTypeOutlineViewController.m
@@ -29,6 +29,7 @@
 @interface RLMTypeOutlineViewController ()
 
 @property (nonatomic, strong) IBOutlet NSOutlineView *classesOutlineView;
+@property (nonatomic) BOOL skipSelectionChangeHandling;
 
 @end
 
@@ -45,6 +46,16 @@
         // We want the class outline to be expanded as default
         [self.classesOutlineView expandItem:firstItem expandChildren:YES];
     }
+}
+
+- (void)reloadData {
+    NSInteger row = self.tableView.selectedRow;
+    [self.tableView reloadData];
+
+    self.skipSelectionChangeHandling = YES;
+    // selectRowIndexes:byExtendingSelection: notifies delegate but this notification should be skipped.
+    [self.tableView selectRowIndexes:[NSIndexSet indexSetWithIndex:row] byExtendingSelection:NO];
+    self.skipSelectionChangeHandling = NO;
 }
 
 #pragma mark - NSOutlineViewDataSource implementation
@@ -125,6 +136,10 @@
 
 - (void)outlineViewSelectionDidChange:(NSNotification *)notification
 {
+    if (self.skipSelectionChangeHandling) {
+        return;
+    }
+
     NSOutlineView *outlineView = notification.object;
     if (outlineView == self.classesOutlineView) {
         NSInteger row = [outlineView selectedRow];


### PR DESCRIPTION
In order to preserve selection in sidebar when external process modifies realm selection was set manually after tableview reload. That selection change shouldn't be handled the same way as a regular selection change.