### PR TITLE
Update fastlane to 2.6.0 and move s3 publishing to internal Jenkins job 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,14 +45,14 @@ GEM
       netrc (= 0.7.8)
     cocoapods-try (1.1.0)
     colored (1.2)
-    commander (4.4.1)
+    commander (4.4.3)
       highline (~> 1.7.2)
     domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.1.1)
     escape (0.0.4)
     excon (0.54.0)
-    faraday (0.10.0)
+    faraday (0.10.1)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
       faraday (>= 0.7.4)
@@ -61,7 +61,7 @@ GEM
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.0.1)
       addressable (~> 2)
-    fastlane (2.1.1)
+    fastlane (2.6.0)
       activesupport (< 5)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -75,7 +75,7 @@ GEM
       faraday_middleware (~> 0.9)
       fastimage (>= 1.6)
       gh_inspector (>= 1.0.1, < 2.0.0)
-      google-api-client (~> 0.9.1)
+      google-api-client (~> 0.9.2)
       highline (>= 1.7.2, < 2.0.0)
       json (< 3.0.0)
       mini_magick (~> 4.5.1)
@@ -139,7 +139,7 @@ GEM
     netrc (0.7.8)
     os (0.9.6)
     plist (3.2.0)
-    public_suffix (2.0.4)
+    public_suffix (2.0.5)
     representable (2.3.0)
       uber (~> 0.0.7)
     retriable (2.1.0)
@@ -183,4 +183,4 @@ DEPENDENCIES
   fastlane
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,5 +46,5 @@ def getVersion() {
   sh "git rev-parse HEAD | cut -b1-8 > sha.txt"
   def sha = readFile('sha.txt').readLines().last().trim()
 
-  return "${version}-${sha}"
+  return "${versionNumber}-${sha}"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,28 +1,5 @@
 #!groovy
 
-def readGitTag() {
-  sh "git describe --exact-match --tags HEAD | tail -n 1 > tag.txt 2>&1 || true"
-  def tag = readFile('tag.txt').trim()
-  return tag
-}
-
-def readGitSha() {
-  sh "git rev-parse HEAD | cut -b1-8 > sha.txt"
-  def sha = readFile('sha.txt').readLines().last().trim()
-  return sha
-}
-
-def getVersion(String version) {
-  def gitTag = readGitTag()
-  def gitSha = readGitSha()
-  
-  if (gitTag == "") {
-    return "${version}-g${gitSha}"
-  } else {
-    return version
-  }
-}
-
 node('osx_vegas') {
   dir('realm-browser') {
     wrap([$class: 'AnsiColorBuildWrapper']) {
@@ -36,15 +13,6 @@ node('osx_vegas') {
         ])
       }
 
-      sh '''
-        awk  '/<key>CFBundleShortVersionString<\\/key>/ { getline; gsub("<[^>]*>", ""); gsub(/\\t/,""); print $0 }' RealmBrowser/Supporting\\ Files/RealmBrowser-Info.plist > currentversion
-      '''
-      def currentVersionNumber = readFile('currentversion').readLines()[0]
-      def currentVersion = 'v' + getVersion(currentVersionNumber)
-      def archiveName = "realm_browser_${currentVersion}.zip"
-      def gitTag = readGitTag()
-      echo archiveName
-
       sh "bundle install"
 
       stage('Test') {
@@ -56,19 +24,27 @@ node('osx_vegas') {
         sh "bundle exec fastlane build"
       }
 
-      stage('Package') {
+      stage('Archive') {
+        def currentVersion = 'v' + getVersion()
+        def archiveName = "realm_browser_${currentVersion}.zip"
+
         dir("build") {
           sh "zip --symlinks -r ${archiveName} *"
           archive "${archiveName}"
         }
       }
-    
-      if (gitTag != "") {
-        stage('Upload to S3') {
-          sh "/usr/local/bin/s3cmd put ${archiveName} 's3://realm-ci-artifacts/browser/${currentVersionNumber.split('_')[0]}/cocoa/'"
-          echo "Uploaded to 's3://realm-ci-artifacts/browser/${currentVersionNumber.split('_')[0]}/cocoa/'"
-        }
-      }
     }
   }
+}
+
+def getVersion() {
+  sh '''
+    awk  '/<key>CFBundleShortVersionString<\\/key>/ { getline; gsub("<[^>]*>", ""); gsub(/\\t/,""); print $0 }' RealmBrowser/Supporting\\ Files/RealmBrowser-Info.plist > currentversion
+  '''
+  def versionNumber = readFile('currentversion').readLines()[0]
+
+  sh "git rev-parse HEAD | cut -b1-8 > sha.txt"
+  def sha = readFile('sha.txt').readLines().last().trim()
+
+  return "${version}-${sha}"
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,7 +4,7 @@
 # HOCKEY_API_TOKEN – HockeyApp API token that has persimmision to upload builds
 # HOCKEY_APP_ID – HockeyApp public application identifier, optional while all apps have different bundle ids
 #
-# FASTLANE_USERNAME and FASTLANE_PASSWORD should be set to iTunes Connect credentials
+# ITC_USERNAME and FASTLANE_PASSWORD should be set to iTunes Connect credentials
 #
 
 fastlane_version "2.1.1"
@@ -44,22 +44,12 @@ lane :build do |options|
     sh("zip --symlinks -r \"#{gitHubArchiveName}\" \"Realm Browser.app\"")
     sh("rm -rf \"Realm Browser.app\"")
   end
-  
+
   # delete incorrect ipa path in lane context
   Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] = nil
 
   # fix dSYM path
   Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH] = "#{buildDir}/#{dSymArhiveName}"
-  
-  if options[:submit_to_hockey]
-    hockey(
-      api_token: ENV['HOCKEY_API_TOKEN'],
-      public_identifier: ENV['HOCKEY_APP_ID'],
-      ipa: "#{buildDir}/#{gitHubArchiveName}", # should be specified to create a new version
-      dsym: "#{buildDir}/#{dSymArhiveName}",
-      strategy: "replace" # this will not replace symbols but add the new ones, we don're really care about app itself anyway
-    )
-  end
   
   if options[:submit_to_itc]
     deliver(
@@ -68,6 +58,15 @@ lane :build do |options|
       pkg: "#{buildDir}/Realm Browser.pkg",
       skip_screenshots: true,
       skip_metadata: true
+    )
+  end
+
+  if options[:submit_to_hockey]
+    hockey(
+      api_token: ENV['HOCKEY_API_TOKEN'],
+      ipa: "#{buildDir}/#{gitHubArchiveName}", # should be specified to create a new version
+      dsym: "#{buildDir}/#{dSymArhiveName}",
+      strategy: "replace" # this will not replace symbols but add the new ones, we don're really care about app itself anyway
     )
   end
 end


### PR DESCRIPTION
Seems like deliver in fastlane 2.1.1 doesn't work anymore, so it's updated to the latest version. Also all release related stuff was moved to an internal private Jenkins job but all the build artifacts are still available from this job.

/cc @radu-tutueanu, @jpsim 