### PR TITLE
Fix crash when cancel loading synced realm

### DIFF
--- a/RealmBrowser/Models/RLMDocument.m
+++ b/RealmBrowser/Models/RLMDocument.m
@@ -228,6 +228,11 @@
     }
 }
 
+- (void)close {
+    [self.schemaLoader cancelSchemaLoading];
+    [super close];
+}
+
 #pragma mark NSDocument overrides
 
 - (void)makeWindowControllers

--- a/RealmBrowserSync/Library/RLMDynamicSchemaLoader.h
+++ b/RealmBrowserSync/Library/RLMDynamicSchemaLoader.h
@@ -25,5 +25,6 @@ typedef void (^RLMSchemaLoadCompletionHandler)(NSError *error);
 - (instancetype)initWithSyncURL:(NSURL *)syncURL user:(RLMSyncUser *)user;
 
 - (void)loadSchemaWithCompletionHandler:(RLMSchemaLoadCompletionHandler)handler;
+- (void)cancelSchemaLoading;
 
 @end

--- a/RealmBrowserSync/Library/RLMDynamicSchemaLoader.m
+++ b/RealmBrowserSync/Library/RLMDynamicSchemaLoader.m
@@ -49,7 +49,7 @@ NSString * const errorDomain = @"RLMDynamicSchemaLoader";
 }
 
 - (void)dealloc {
-    [self.notificationToken stop];
+    [self cancelSchemaLoading];
 }
 
 - (void)loadSchemaWithCompletionHandler:(RLMSchemaLoadCompletionHandler)handler {
@@ -80,6 +80,11 @@ NSString * const errorDomain = @"RLMDynamicSchemaLoader";
     }];
 
     [self performSelector:@selector(schemaLoadingTimeout) withObject:nil afterDelay:schemaLoadTimeout];
+}
+
+- (void)cancelSchemaLoading {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self];
+    [self.notificationToken stop];
 }
 
 - (void)schemaDidLoadWithError:(NSError *)error {


### PR DESCRIPTION
If document window is closed before realm url is loaded `schemaLoader` should stop handle timeout and waiting for changes.

/cc @jpsim 