### PR TITLE
Save javascript model definitions

### DIFF
--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -316,6 +316,11 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
     [self saveModelsForLanguage:RLMModelExporterLanguageSwift];
 }
 
+- (IBAction)saveJavascriptModels:(id)sender
+{
+    [self saveModelsForLanguage:RLMModelExporterLanguageJavascript];
+}
+
 - (IBAction)exportToCompactedRealm:(id)sender
 {
     NSString *fileName = self.document.fileURL.lastPathComponent ?: self.document.syncURL.lastPathComponent ?: @"Compacted";

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -316,7 +316,7 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
     [self saveModelsForLanguage:RLMModelExporterLanguageSwift];
 }
 
-- (IBAction)saveJavascriptModels:(id)sender
+- (IBAction)saveJavaScriptModels:(id)sender
 {
     [self saveModelsForLanguage:RLMModelExporterLanguageJavascript];
 }

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -318,7 +318,7 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
 
 - (IBAction)saveJavaScriptModels:(id)sender
 {
-    [self saveModelsForLanguage:RLMModelExporterLanguageJavascript];
+    [self saveModelsForLanguage:RLMModelExporterLanguageJavaScript];
 }
 
 - (IBAction)exportToCompactedRealm:(id)sender

--- a/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
+++ b/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
@@ -136,10 +136,10 @@
                                                 <action selector="saveSwiftModels:" target="-1" id="7le-yg-BNa"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Save Javascript definitions..." id="YBd-iW-lGC">
+                                        <menuItem title="Save JavaScript definitions..." id="YBd-iW-lGC">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="saveJavascriptModels:" target="-1" id="fc9-Au-OUZ"/>
+                                                <action selector="saveJavaScriptModels:" target="-1" id="HHN-6e-uP7"/>
                                             </connections>
                                         </menuItem>
                                     </items>

--- a/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
+++ b/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -134,6 +134,12 @@
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="saveSwiftModels:" target="-1" id="7le-yg-BNa"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save Javascript definitions..." id="YBd-iW-lGC">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="saveJavascriptModels:" target="-1" id="fc9-Au-OUZ"/>
                                             </connections>
                                         </menuItem>
                                     </items>

--- a/RealmBrowser/Support/RLMModelExporter.h
+++ b/RealmBrowser/Support/RLMModelExporter.h
@@ -22,7 +22,7 @@ typedef NS_ENUM(NSInteger, RLMModelExporterLanguage) {
     RLMModelExporterLanguageJava,
     RLMModelExporterLanguageObjectiveC,
     RLMModelExporterLanguageSwift,
-    RLMModelExporterLanguageJavascript
+    RLMModelExporterLanguageJavaScript
 };
 
 @interface RLMModelExporter : NSObject

--- a/RealmBrowser/Support/RLMModelExporter.h
+++ b/RealmBrowser/Support/RLMModelExporter.h
@@ -21,7 +21,8 @@
 typedef NS_ENUM(NSInteger, RLMModelExporterLanguage) {
     RLMModelExporterLanguageJava,
     RLMModelExporterLanguageObjectiveC,
-    RLMModelExporterLanguageSwift
+    RLMModelExporterLanguageSwift,
+    RLMModelExporterLanguageJavascript
 };
 
 @interface RLMModelExporter : NSObject

--- a/RealmBrowser/Support/RLMModelExporter.m
+++ b/RealmBrowser/Support/RLMModelExporter.m
@@ -560,11 +560,11 @@
         return [NSString stringWithFormat:@"    %@: '%@'", property.name, [props objectForKey:@"type"]];
     }
     
-    NSMutableString* definition = [NSMutableString stringWithFormat:@"    %@: {", property.name];
+    NSMutableString *definition = [NSMutableString stringWithFormat:@"    %@: {", property.name];
     int count = (int)[props count],
         check = 0;
-    for (NSString* key in props) {
-        NSString* value = [NSString stringWithFormat:@"'%@'", [props objectForKey:key]];
+    for (NSString *key in props) {
+        NSString *value = [NSString stringWithFormat:@"'%@'", [props objectForKey:key]];
         if ([key isEqualToString:@"indexed"] || [key isEqualToString:@"optional"]) {
             value = [props objectForKey:key];
         }

--- a/RealmBrowser/Support/RLMModelExporter.m
+++ b/RealmBrowser/Support/RLMModelExporter.m
@@ -74,7 +74,7 @@
             });
             break;
         }
-        case RLMModelExporterLanguageJavascript:
+        case RLMModelExporterLanguageJavaScript:
         {
             saveSingleFile(^(NSString *fileName){
                 return [self javaScriptModelsOfSchemas:objectSchemas withFileName:fileName];
@@ -465,7 +465,7 @@
     return nil;
 }
 
-#pragma mark - Private methods - Javascript helpers
+#pragma mark - Private methods - JavaScript helpers
 
 + (NSArray *)javaScriptModelsOfSchemas:(NSArray *)schemas withFileName:(NSString *)fileName
 {

--- a/RealmBrowser/Support/RLMModelExporter.m
+++ b/RealmBrowser/Support/RLMModelExporter.m
@@ -477,7 +477,7 @@
         [exports appendFormat:@"  %@", schemaName];
         [exports appendFormat:@"%@", (schema != [schemas lastObject]) ? @",\n" : @"\n"];
         
-        [contents appendFormat:@"const %@ {\n", schemaName];
+        [contents appendFormat:@"const %@ = {\n", schemaName];
         [contents appendFormat:@"  name: '%@',\n", schema.className];
         NSMutableString *properties = [NSMutableString stringWithString:@"  properties: {\n"];
         NSString *primaryKey = nil;

--- a/RealmBrowser/Support/RLMModelExporter.m
+++ b/RealmBrowser/Support/RLMModelExporter.m
@@ -577,7 +577,11 @@
     int count = (int)[props count],
         check = 0;
     for (NSString* key in props) {
-        [definition appendFormat:@" %@: '%@'%@", key, [props objectForKey:key], (++check == count) ? @" }" : @", "];
+        NSString* value = [NSString stringWithFormat:@"'%@'", [props objectForKey:key]];
+        if ([key isEqualToString:@"indexed"] || [key isEqualToString:@"optional"]) {
+            value = [props objectForKey:key];
+        }
+        [definition appendFormat:@" %@: %@%@", key, value, (++check == count) ? @" }" : @", "];
     }
     
     return definition;

--- a/RealmBrowser/Support/RLMModelExporter.m
+++ b/RealmBrowser/Support/RLMModelExporter.m
@@ -116,7 +116,7 @@
         case RLMModelExporterLanguageJava: return @"Java";
         case RLMModelExporterLanguageObjectiveC: return @"Objective-C";
         case RLMModelExporterLanguageSwift: return @"Swift";
-        case RLMModelExporterLanguageJavascript: return @"Javascript";
+        case RLMModelExporterLanguageJavascript: return @"JavaScript";
     }
 }
 

--- a/RealmBrowser/Support/RLMModelExporter.m
+++ b/RealmBrowser/Support/RLMModelExporter.m
@@ -116,7 +116,7 @@
         case RLMModelExporterLanguageJava: return @"Java";
         case RLMModelExporterLanguageObjectiveC: return @"Objective-C";
         case RLMModelExporterLanguageSwift: return @"Swift";
-        case RLMModelExporterLanguageJavascript: return @"JavaScript";
+        case RLMModelExporterLanguageJavaScript: return @"JavaScript";
     }
 }
 


### PR DESCRIPTION
Simple saving of model definitions in javascript for use in React-Native or node js.  Saves all schema definitions into a single js file (It adds the `Schema` text after the actual table name).   The schema `const`s are exported at the bottom of the file through `module.exports`.  It might not handle every case but is at least a good start for exporting models from existing realm files!

<img width="488" alt="screen shot 2017-02-01 at 12 07 49 am" src="https://cloud.githubusercontent.com/assets/5408505/22496902/501626a8-e813-11e6-997a-70eeb95a4072.png">

<img width="611" alt="screen shot 2017-02-01 at 10 03 21 pm" src="https://cloud.githubusercontent.com/assets/5408505/22536795/5110fb52-e8ca-11e6-9ce9-86a17618a5bc.png">


<img width="237" alt="screen shot 2017-02-01 at 12 10 05 am" src="https://cloud.githubusercontent.com/assets/5408505/22496907/5ced8de4-e813-11e6-9e4d-a42ceb1e8399.png">

