### PR TITLE
Add an option to object context menu to copy cell value

### DIFF
--- a/RealmBrowser/Controllers/RLMInstanceTableViewController.m
+++ b/RealmBrowser/Controllers/RLMInstanceTableViewController.m
@@ -493,6 +493,19 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     [self.parentWindowController reloadAllWindows];
 }
 
+- (void)copyValueFromRow:(NSInteger)row column:(NSInteger)column {
+    NSInteger propertyIndex = [self propertyIndexForColumn:column];
+    RLMClassProperty *classProperty = self.displayedType.propertyColumns[propertyIndex];
+    RLMObject *selectedInstance = [self.displayedType instanceAtIndex:row];
+    id propertyValue = selectedInstance[classProperty.name];
+    RLMPropertyType type = classProperty.type;
+    NSString *string = [realmDescriptions printablePropertyValue:propertyValue ofType:type];
+    
+    NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+    [pasteboard clearContents];
+    [pasteboard writeObjects:@[ string ]];
+}
+
 - (void)addNewObjects:(NSIndexSet *)rowIndexes
 {
     RLMRealm *realm = self.parentWindowController.document.presentedRealm.realm;

--- a/RealmBrowser/Views/RLMTableView.h
+++ b/RealmBrowser/Views/RLMTableView.h
@@ -60,6 +60,8 @@ typedef struct {
 
 - (void)deleteObjects:(NSIndexSet *)rowIndexes;
 
+- (void)copyValueFromRow:(NSInteger)row column:(NSInteger)column;
+
 // RLMArray operations
 - (void)removeRows:(NSIndexSet *)rowIndexes;
 

--- a/RealmBrowser/Views/RLMTableView.m
+++ b/RealmBrowser/Views/RLMTableView.m
@@ -36,6 +36,7 @@ const NSInteger NOT_A_COLUMN = -1;
     NSMenuItem *clickLockItem;
 
     NSMenuItem *deleteObjectItem;
+    NSMenuItem *copyValueItem;
 
     NSMenuItem *removeFromArrayItem;
     NSMenuItem *deleteRowItem;
@@ -102,6 +103,11 @@ const NSInteger NOT_A_COLUMN = -1;
                                                   action:@selector(deleteObjectsAction:)
                                            keyEquivalent:@""];
     deleteObjectItem.tag = 200;
+    
+    copyValueItem = [[NSMenuItem alloc] initWithTitle:@"Copy value"
+                                                  action:@selector(copyValueAction:)
+                                           keyEquivalent:@""];
+    copyValueItem.tag = 201;
 
     // Operations on objects in arrays
     removeFromArrayItem = [[NSMenuItem alloc] initWithTitle:@"Remove objects from array"
@@ -184,6 +190,7 @@ const NSInteger NOT_A_COLUMN = -1;
     }
     else {
         [self.menu addItem:deleteObjectItem];
+        [self.menu addItem:copyValueItem];
     }
     
     if (!actualColumn) {
@@ -330,6 +337,12 @@ const NSInteger NOT_A_COLUMN = -1;
     if (!self.realmDelegate.displaysArray && !self.realmDelegate.realmIsLocked) {
         [self.realmDelegate deleteObjects:self.selectedRowIndexes];
     }
+}
+
+// Copies the value from the cell that was right-clicked
+- (IBAction)copyValueAction:(id)sender
+{
+    [self.realmDelegate copyValueFromRow:self.clickedRow column:self.clickedColumn];
 }
 
 // Add objects of the current type, according to number of selected rows


### PR DESCRIPTION
This commit adds a "Copy value" item to the object context menu, which, when selected, copies the value of the cell that was right-clicked.  I'm using a UUID for my primary key, and found that I couldn't double-click in the primary key to edit it, so I needed a quick way to get the value.