### PR TITLE
Save C# model definitions

### DIFF
--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -298,7 +298,7 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
 - (void)saveModelsForLanguage:(RLMModelExporterLanguage)language
 {
     NSArray *objectSchemas = self.document.presentedRealm.realm.schema.objectSchema;
-    [RLMModelExporter saveModelsForSchemas:objectSchemas inLanguage:language];
+    [RLMModelExporter saveModelsForSchemas:objectSchemas inLanguage:language window:self.window];
 }
 
 - (IBAction)saveJavaModels:(id)sender

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -321,6 +321,11 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
     [self saveModelsForLanguage:RLMModelExporterLanguageJavaScript];
 }
 
+- (IBAction)saveCSharpModels:(id)sender
+{
+    [self saveModelsForLanguage:RLMModelExporterLanguageCSharp];
+}
+
 - (IBAction)exportToCompactedRealm:(id)sender
 {
     NSString *fileName = self.document.fileURL.lastPathComponent ?: self.document.syncURL.lastPathComponent ?: @"Compacted";

--- a/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
+++ b/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
@@ -118,31 +118,31 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Save Model Definitions" id="YSO-b8-a2a">
                                     <items>
-                                        <menuItem title="Save Java definitions..." id="kuf-fu-JL0">
+                                        <menuItem title="Java..." id="kuf-fu-JL0">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="saveJavaModels:" target="-1" id="6op-mb-kj6"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Save Objective-C definitions..." id="yRS-DK-aHw">
+                                        <menuItem title="Objective-C..." id="yRS-DK-aHw">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="saveObjcModels:" target="-1" id="6Rj-7H-W6J"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Save Swift definitions..." id="Nxi-3A-mZH">
+                                        <menuItem title="Swift..." id="Nxi-3A-mZH">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="saveSwiftModels:" target="-1" id="7le-yg-BNa"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Save JavaScript definitions..." id="YBd-iW-lGC">
+                                        <menuItem title="JavaScript..." id="YBd-iW-lGC">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="saveJavaScriptModels:" target="-1" id="HHN-6e-uP7"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Save C# definitions..." id="IEI-T6-yOj">
+                                        <menuItem title="C#..." id="IEI-T6-yOj">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="saveCSharpModels:" target="-1" id="6CY-YI-2fe"/>

--- a/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
+++ b/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
@@ -142,6 +142,12 @@
                                                 <action selector="saveJavaScriptModels:" target="-1" id="HHN-6e-uP7"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Save C# definitions..." id="IEI-T6-yOj">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="saveCSharpModels:" target="-1" id="6CY-YI-2fe"/>
+                                            </connections>
+                                        </menuItem>
                                     </items>
                                 </menu>
                             </menuItem>

--- a/RealmBrowser/Support/RLMModelExporter.h
+++ b/RealmBrowser/Support/RLMModelExporter.h
@@ -28,6 +28,6 @@ typedef NS_ENUM(NSInteger, RLMModelExporterLanguage) {
 
 @interface RLMModelExporter : NSObject
 
-+ (void)saveModelsForSchemas:(NSArray *)objectSchemas inLanguage:(RLMModelExporterLanguage)language;
++ (void)saveModelsForSchemas:(NSArray *)objectSchemas inLanguage:(RLMModelExporterLanguage)language window:(NSWindow *)window;
 
 @end

--- a/RealmBrowser/Support/RLMModelExporter.h
+++ b/RealmBrowser/Support/RLMModelExporter.h
@@ -22,7 +22,8 @@ typedef NS_ENUM(NSInteger, RLMModelExporterLanguage) {
     RLMModelExporterLanguageJava,
     RLMModelExporterLanguageObjectiveC,
     RLMModelExporterLanguageSwift,
-    RLMModelExporterLanguageJavaScript
+    RLMModelExporterLanguageJavaScript,
+    RLMModelExporterLanguageCSharp
 };
 
 @interface RLMModelExporter : NSObject

--- a/RealmBrowser/Support/RLMModelExporter.m
+++ b/RealmBrowser/Support/RLMModelExporter.m
@@ -40,12 +40,10 @@
 
 #pragma mark - Public methods
 
-+ (void)saveModelsForSchemas:(NSArray *)objectSchemas inLanguage:(RLMModelExporterLanguage)language
++ (void)saveModelsForSchemas:(NSArray *)objectSchemas inLanguage:(RLMModelExporterLanguage)language window:(NSWindow *)window
 {
     void(^saveMultipleFiles)(NSSavePanel *, void(^)()) = ^void(NSSavePanel *panel, void(^completionBlock)()) {
-        panel.canCreateDirectories = YES;
-        panel.title = [NSString stringWithFormat:@"Save %@ model definitions", [RLMModelExporter stringForLanguage:language]];
-        [panel beginWithCompletionHandler:^(NSInteger result) {
+        [panel beginSheetModalForWindow:window completionHandler:^(NSInteger result) {
             if (result == NSFileHandlingPanelOKButton) {
                 [panel orderOut:self];
                 completionBlock(panel);
@@ -57,6 +55,7 @@
         NSSavePanel *panel = [NSSavePanel savePanel];
         panel.prompt = @"Save";
         panel.nameFieldStringValue = @"RealmModels";
+
         saveMultipleFiles(panel, ^{
             NSString *fileName = [[panel.URL lastPathComponent] stringByDeletingPathExtension];
             [self saveModels:modelsWithFileName(fileName) toFolder:[panel.URL URLByDeletingLastPathComponent]];
@@ -68,8 +67,10 @@
         {
             NSOpenPanel *panel = [NSOpenPanel openPanel];
             panel.prompt = @"Select folder";
+            panel.canCreateDirectories = YES;
             panel.canChooseDirectories = YES;
             panel.canChooseFiles = NO;
+
             saveMultipleFiles(panel, ^{
                 [self saveModels:[self javaModelsOfSchemas:objectSchemas] toFolder:panel.URL];
             });
@@ -131,18 +132,6 @@
         [securityScopedURL stopAccessingSecurityScopedResource];
     }];
 }
-
-+ (NSString *)stringForLanguage:(RLMModelExporterLanguage)language
-{
-    switch (language) {
-        case RLMModelExporterLanguageJava: return @"Java";
-        case RLMModelExporterLanguageObjectiveC: return @"Objective-C";
-        case RLMModelExporterLanguageSwift: return @"Swift";
-        case RLMModelExporterLanguageJavaScript: return @"JavaScript";
-        case RLMModelExporterLanguageCSharp: return @"C#";
-    }
-}
-
 
 #pragma mark - Private methods - Java helpers
 


### PR DESCRIPTION
This is the final step to support saving model definitions for all languages Realm supports :)

I've tested it a bit but it'd be great to have another pair of eyes especially from .NET team. You can get a prebuilt version [here](https://ci.realm.io/job/realm/job/realm-browser-osx/job/do-dotnet-model-definitions/1/).

/cc @kristiandupont, @fealebenpae, @nirinchev, @jpsim 