### PR TITLE
Saving credentials to the keychain

### DIFF
--- a/RealmBrowser.xcodeproj/project.pbxproj
+++ b/RealmBrowser.xcodeproj/project.pbxproj
@@ -94,6 +94,9 @@
 		C2D302E81D7478AC00E091DF /* OpenSyncURLWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = C2D302E71D7478AC00E091DF /* OpenSyncURLWindow.xib */; };
 		C2D302EB1D747BF600E091DF /* RLMSyncURLValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = C2D302EA1D747BF600E091DF /* RLMSyncURLValueTransformer.m */; };
 		C2D302EE1D75A2E100E091DF /* RLMWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C2D302ED1D75A2E100E091DF /* RLMWindowController.m */; };
+		DD2F4D631E9DCE10008EA2FB /* RLMKeychainInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = DD2F4D621E9DCE10008EA2FB /* RLMKeychainInfo.m */; };
+		DD2F4D661E9DD1E5008EA2FB /* RLMKeychainInfo+RLMSyncCredentials.m in Sources */ = {isa = PBXBuildFile; fileRef = DD2F4D651E9DD1E5008EA2FB /* RLMKeychainInfo+RLMSyncCredentials.m */; };
+		DD70EFFF1E9D9FC00074C115 /* RLMKeychainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = DD70EFFE1E9D9FC00074C115 /* RLMKeychainStore.m */; };
 		E84EB8291A2FC38C00EB780E /* RLMTestObjects.m in Sources */ = {isa = PBXBuildFile; fileRef = E84EB8281A2FC38C00EB780E /* RLMTestObjects.m */; };
 /* End PBXBuildFile section */
 
@@ -266,6 +269,12 @@
 		C2D302EC1D75A2E100E091DF /* RLMWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMWindowController.h; sourceTree = "<group>"; };
 		C2D302ED1D75A2E100E091DF /* RLMWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMWindowController.m; sourceTree = "<group>"; };
 		C686DBCA1CE3F34837DB465F /* Pods-RealmBrowser-RealmBrowserTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RealmBrowser-RealmBrowserTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-RealmBrowser-RealmBrowserTests/Pods-RealmBrowser-RealmBrowserTests.release.xcconfig"; sourceTree = "<group>"; };
+		DD2F4D611E9DCE10008EA2FB /* RLMKeychainInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMKeychainInfo.h; sourceTree = "<group>"; };
+		DD2F4D621E9DCE10008EA2FB /* RLMKeychainInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMKeychainInfo.m; sourceTree = "<group>"; };
+		DD2F4D641E9DD1E5008EA2FB /* RLMKeychainInfo+RLMSyncCredentials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RLMKeychainInfo+RLMSyncCredentials.h"; sourceTree = "<group>"; };
+		DD2F4D651E9DD1E5008EA2FB /* RLMKeychainInfo+RLMSyncCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RLMKeychainInfo+RLMSyncCredentials.m"; sourceTree = "<group>"; };
+		DD70EFFD1E9D9FC00074C115 /* RLMKeychainStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMKeychainStore.h; sourceTree = "<group>"; };
+		DD70EFFE1E9D9FC00074C115 /* RLMKeychainStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMKeychainStore.m; sourceTree = "<group>"; };
 		E84EB8271A2FC38C00EB780E /* RLMTestObjects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMTestObjects.h; sourceTree = "<group>"; };
 		E84EB8281A2FC38C00EB780E /* RLMTestObjects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMTestObjects.m; sourceTree = "<group>"; };
 		EB46D9299721CA4725D511E6 /* Pods_RealmBrowser_RealmBrowserTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RealmBrowser_RealmBrowserTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -488,6 +497,7 @@
 		C23F6A3D1D648AA3003C4E71 /* Library */ = {
 			isa = PBXGroup;
 			children = (
+				DD2F4D601E9DCDFC008EA2FB /* Keychain */,
 				C2644B051D6491F900DBAC67 /* RLMDynamicSchemaLoader.h */,
 				C2644B061D6491F900DBAC67 /* RLMDynamicSchemaLoader.m */,
 				C2D302E91D747BF600E091DF /* RLMSyncURLValueTransformer.h */,
@@ -500,6 +510,19 @@
 				C26CC79F1DB6497900EE549D /* RLMSyncUtils.m */,
 			);
 			path = Library;
+			sourceTree = "<group>";
+		};
+		DD2F4D601E9DCDFC008EA2FB /* Keychain */ = {
+			isa = PBXGroup;
+			children = (
+				DD2F4D611E9DCE10008EA2FB /* RLMKeychainInfo.h */,
+				DD2F4D621E9DCE10008EA2FB /* RLMKeychainInfo.m */,
+				DD70EFFD1E9D9FC00074C115 /* RLMKeychainStore.h */,
+				DD70EFFE1E9D9FC00074C115 /* RLMKeychainStore.m */,
+				DD2F4D641E9DD1E5008EA2FB /* RLMKeychainInfo+RLMSyncCredentials.h */,
+				DD2F4D651E9DD1E5008EA2FB /* RLMKeychainInfo+RLMSyncCredentials.m */,
+			);
+			name = Keychain;
 			sourceTree = "<group>";
 		};
 		E83626C41CE35C4300E9493D /* Application */ = {
@@ -873,6 +896,7 @@
 				C2CA58F01DAE3B6B0052BAAA /* RLMApplicationDelegate+CrashReporting.m in Sources */,
 				84E35A4D196B021B007F0344 /* RLMArrayNavigationState.m in Sources */,
 				C2D302EE1D75A2E100E091DF /* RLMWindowController.m in Sources */,
+				DD2F4D661E9DD1E5008EA2FB /* RLMKeychainInfo+RLMSyncCredentials.m in Sources */,
 				84446534195891AA00CEEA5B /* RLMViewController.m in Sources */,
 				C29CC7CA1D76F57F00186B29 /* NSView+RLMExtensions.m in Sources */,
 				84D7990C19388E8900FC76A0 /* RLMClassProperty.m in Sources */,
@@ -897,12 +921,14 @@
 				C26CC7A01DB6497900EE549D /* RLMSyncUtils.m in Sources */,
 				8474E2B419544D8000BCA755 /* RLMTypeOutlineViewController.m in Sources */,
 				2249D9B219A62EBD00A31104 /* RLMTableColumn.m in Sources */,
+				DD2F4D631E9DCE10008EA2FB /* RLMKeychainInfo.m in Sources */,
 				C277A6EA1D7D9A0100DED239 /* RLMFacebookCredentialViewController.m in Sources */,
 				220D382819B639D700F79496 /* RLMTestDataGenerator.m in Sources */,
 				84E35A42196A9F3B007F0344 /* RLMNavigationState.m in Sources */,
 				C277A6ED1D7EC03B00DED239 /* RLMGoogleCredentialViewController.m in Sources */,
 				84D7990D19388E8900FC76A0 /* RLMRealmNode.m in Sources */,
 				22565D6719C1BCF400C8C8EC /* RLMLinkTableCellView.m in Sources */,
+				DD70EFFF1E9D9FC00074C115 /* RLMKeychainStore.m in Sources */,
 				221322FA19954AB100D25737 /* RLMImageTableCellView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RealmBrowserSync/Controllers/RLMConnectToServerWindowController.m
+++ b/RealmBrowserSync/Controllers/RLMConnectToServerWindowController.m
@@ -81,6 +81,8 @@ NSString * const RLMConnectToServerWindowControllerErrorDomain = @"io.realm.real
 
     _serverURL = [url copy];
 
+    [self loadKeychainCredentials];
+    
     [self updateUI];
 }
 
@@ -147,10 +149,16 @@ NSString * const RLMConnectToServerWindowControllerErrorDomain = @"io.realm.real
 - (void)loadRecentCredentials {
     self.serverURL = [[NSUserDefaults standardUserDefaults] URLForKey:serverURLKey];
     
+    [self loadKeychainCredentials];
+}
+
+- (void)loadKeychainCredentials {
     RLMKeychainInfo *info = [self.keychainStore savedCredentialsForServer:self.serverURL];
     RLMSyncCredentials *savedCredentials = info.credentials;
     
-    if (!savedCredentials) return;
+    if (!savedCredentials) {
+        savedCredentials = [RLMKeychainInfo emptyCredentialsWithProvider:self.credentials.provider];
+    }
     
     self.credentials = savedCredentials;
 }

--- a/RealmBrowserSync/Controllers/RLMConnectToServerWindowController.m
+++ b/RealmBrowserSync/Controllers/RLMConnectToServerWindowController.m
@@ -165,6 +165,9 @@ NSString * const RLMConnectToServerWindowControllerErrorDomain = @"io.realm.real
 
 - (void)saveRecentCredentials {
     [[NSUserDefaults standardUserDefaults] setURL:self.serverURL forKey:serverURLKey];
+    
+    if (!self.shouldSaveCredentials) return;
+    
     [self.keychainStore saveCredentials:self.credentials forServer:self.serverURL];
 }
 

--- a/RealmBrowserSync/Controllers/RLMUsernameCredentialViewController.m
+++ b/RealmBrowserSync/Controllers/RLMUsernameCredentialViewController.m
@@ -19,6 +19,8 @@
 #import "RLMUsernameCredentialViewController.h"
 #import "RLMCredentialViewController+Private.h"
 
+extern NSString *const kRLMSyncPasswordKey;
+
 @interface RLMUsernameCredentialViewController ()
 
 @property (nonatomic, weak) IBOutlet NSTextField *usernameTextField;
@@ -49,6 +51,9 @@
 
 - (void)setCredentials:(RLMSyncCredentials *)credentials {
     self.usernameTextField.stringValue = credentials.token;
+    
+    NSString *password = [credentials.userInfo objectForKey:kRLMSyncPasswordKey];
+    if (password) self.passwordTextField.stringValue = password;
 }
 
 @end

--- a/RealmBrowserSync/Library/RLMKeychainInfo+RLMSyncCredentials.h
+++ b/RealmBrowserSync/Library/RLMKeychainInfo+RLMSyncCredentials.h
@@ -1,0 +1,17 @@
+//
+//  RLMKeychainInfo+RLMSyncCredentials.h
+//  RealmBrowser
+//
+//  Created by Guilherme Rambo on 12/04/17.
+//  Copyright © 2017 Realm inc. All rights reserved.
+//
+
+#import "RLMKeychainInfo.h"
+
+@import Realm;
+
+@interface RLMKeychainInfo (RLMSyncCredentials)
+
+@property (nonatomic, readonly) RLMSyncCredentials *credentials;
+
+@end

--- a/RealmBrowserSync/Library/RLMKeychainInfo+RLMSyncCredentials.h
+++ b/RealmBrowserSync/Library/RLMKeychainInfo+RLMSyncCredentials.h
@@ -14,4 +14,6 @@
 
 @property (nonatomic, readonly) RLMSyncCredentials *credentials;
 
++ (RLMSyncCredentials *)emptyCredentialsWithProvider:(RLMIdentityProvider)provider;
+
 @end

--- a/RealmBrowserSync/Library/RLMKeychainInfo+RLMSyncCredentials.h
+++ b/RealmBrowserSync/Library/RLMKeychainInfo+RLMSyncCredentials.h
@@ -15,5 +15,6 @@
 @property (nonatomic, readonly) RLMSyncCredentials *credentials;
 
 + (RLMSyncCredentials *)emptyCredentialsWithProvider:(RLMIdentityProvider)provider;
+- (BOOL)isEqualToCredentials:(RLMSyncCredentials *)credentials;
 
 @end

--- a/RealmBrowserSync/Library/RLMKeychainInfo+RLMSyncCredentials.m
+++ b/RealmBrowserSync/Library/RLMKeychainInfo+RLMSyncCredentials.m
@@ -25,4 +25,19 @@
     }
 }
 
++ (RLMSyncCredentials *)emptyCredentialsWithProvider:(RLMIdentityProvider)provider
+{
+    if ([provider isEqualToString:RLMIdentityProviderUsernamePassword]) {
+        return [RLMSyncCredentials credentialsWithUsername:@"" password:@"" register:NO];
+    } else if ([provider isEqualToString:RLMIdentityProviderGoogle]) {
+        return [RLMSyncCredentials credentialsWithGoogleToken:@""];
+    } else if ([provider isEqualToString:RLMIdentityProviderCloudKit]) {
+        return [RLMSyncCredentials credentialsWithCloudKitToken:@""];
+    } else if ([provider isEqualToString:RLMIdentityProviderFacebook]) {
+        return [RLMSyncCredentials credentialsWithFacebookToken:@""];
+    } else {
+        return [RLMSyncCredentials credentialsWithAccessToken:@"" identity:[NSUUID UUID].UUIDString];
+    }
+}
+
 @end

--- a/RealmBrowserSync/Library/RLMKeychainInfo+RLMSyncCredentials.m
+++ b/RealmBrowserSync/Library/RLMKeychainInfo+RLMSyncCredentials.m
@@ -40,4 +40,11 @@
     }
 }
 
+- (BOOL)isEqualToCredentials:(RLMSyncCredentials *)credentials
+{
+    return [credentials.provider isEqualToString:self.provider]
+            && [credentials.token isEqualToString:self.token]
+            && [credentials.userInfo[@"password"] isEqualToString:self.password];
+}
+
 @end

--- a/RealmBrowserSync/Library/RLMKeychainInfo+RLMSyncCredentials.m
+++ b/RealmBrowserSync/Library/RLMKeychainInfo+RLMSyncCredentials.m
@@ -1,0 +1,28 @@
+//
+//  RLMKeychainInfo+RLMSyncCredentials.m
+//  RealmBrowser
+//
+//  Created by Guilherme Rambo on 12/04/17.
+//  Copyright © 2017 Realm inc. All rights reserved.
+//
+
+#import "RLMKeychainInfo+RLMSyncCredentials.h"
+
+@implementation RLMKeychainInfo (RLMSyncCredentials)
+
+- (RLMSyncCredentials *)credentials
+{
+    if ([self.provider isEqualToString:RLMIdentityProviderUsernamePassword]) {
+        return [RLMSyncCredentials credentialsWithUsername:self.token password:self.password register:NO];
+    } else if ([self.provider isEqualToString:RLMIdentityProviderGoogle]) {
+        return [RLMSyncCredentials credentialsWithGoogleToken:self.token];
+    } else if ([self.provider isEqualToString:RLMIdentityProviderCloudKit]) {
+        return [RLMSyncCredentials credentialsWithCloudKitToken:self.token];
+    } else if ([self.provider isEqualToString:RLMIdentityProviderFacebook]) {
+        return [RLMSyncCredentials credentialsWithFacebookToken:self.token];
+    } else {
+        return [RLMSyncCredentials credentialsWithAccessToken:self.token identity:[NSUUID UUID].UUIDString];
+    }
+}
+
+@end

--- a/RealmBrowserSync/Library/RLMKeychainInfo.h
+++ b/RealmBrowserSync/Library/RLMKeychainInfo.h
@@ -1,0 +1,17 @@
+//
+//  RLMKeychainInfo.h
+//  RealmBrowser
+//
+//  Created by Guilherme Rambo on 11/04/17.
+//  Copyright © 2017 Realm inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface RLMKeychainInfo : NSObject
+
+@property (nonatomic, copy) NSString *provider;
+@property (nonatomic, copy) NSString *token;
+@property (nonatomic, copy) NSString *password;
+
+@end

--- a/RealmBrowserSync/Library/RLMKeychainInfo.m
+++ b/RealmBrowserSync/Library/RLMKeychainInfo.m
@@ -1,0 +1,13 @@
+//
+//  RLMKeychainInfo.m
+//  RealmBrowser
+//
+//  Created by Guilherme Rambo on 11/04/17.
+//  Copyright © 2017 Realm inc. All rights reserved.
+//
+
+#import "RLMKeychainInfo.h"
+
+@implementation RLMKeychainInfo
+
+@end

--- a/RealmBrowserSync/Library/RLMKeychainStore.h
+++ b/RealmBrowserSync/Library/RLMKeychainStore.h
@@ -1,0 +1,18 @@
+//
+//  RLMKeychainStore.h
+//  RealmBrowser
+//
+//  Created by Guilherme Rambo on 11/04/17.
+//  Copyright © 2017 Realm inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class RLMSyncCredentials, RLMKeychainInfo;
+
+@interface RLMKeychainStore : NSObject
+
+- (void)saveCredentials:(RLMSyncCredentials *)credentials forServer:(NSURL *)serverURL;
+- (RLMKeychainInfo *)savedCredentialsForServer:(NSURL *)serverURL;
+
+@end

--- a/RealmBrowserSync/Library/RLMKeychainStore.m
+++ b/RealmBrowserSync/Library/RLMKeychainStore.m
@@ -1,0 +1,105 @@
+//
+//  RLMKeychainStore.m
+//  RealmBrowser
+//
+//  Created by Guilherme Rambo on 11/04/17.
+//  Copyright © 2017 Realm inc. All rights reserved.
+//
+
+#import "RLMKeychainStore.h"
+
+#import "RLMKeychainInfo.h"
+
+@import Security;
+@import Realm;
+
+const char * kRLMKeychainServiceName = "Realm Browser";
+
+NSString * const kRLMKeychainTokenKey = @"token";
+NSString * const kRLMKeychainPasswordKey = @"password";
+NSString * const kRLMKeychainProviderKey = @"provider";
+
+@interface RLMKeychainInfo (KeychainDictionary)
+
++ (instancetype)keychainInfoFromKeychainDictionary:(NSDictionary *)dict;
+
+@end
+
+@implementation RLMKeychainStore
+
+- (void)saveCredentials:(RLMSyncCredentials *)credentials forServer:(NSURL *)serverURL
+{
+    if (!credentials.userInfo || !credentials.token) return;
+    
+    UInt32 serverAddressLength = (UInt32)serverURL.absoluteString.length;
+    const char *serverAddress = serverURL.absoluteString.UTF8String;
+    
+    NSDictionary *accountInfo = [self keychainDictionaryFromCredentials:credentials];
+    
+    NSData *plist = [NSPropertyListSerialization dataWithPropertyList:accountInfo format:NSPropertyListXMLFormat_v1_0 options:NSPropertyListImmutable error:NULL];
+    
+    if (!plist) return;
+    
+    SecKeychainAddGenericPassword(NULL,
+                                  (UInt32)strlen(kRLMKeychainServiceName),
+                                  kRLMKeychainServiceName,
+                                  serverAddressLength,
+                                  serverAddress,
+                                  (UInt32)plist.length,
+                                  plist.bytes,
+                                  NULL);
+}
+
+- (RLMKeychainInfo *)savedCredentialsForServer:(NSURL *)serverURL
+{
+    UInt32 serverAddressLength = (UInt32)serverURL.absoluteString.length;
+    const char *serverAddress = serverURL.absoluteString.UTF8String;
+    
+    void *plistPointer;
+    UInt32 plistLength = 0;
+    
+    OSStatus result = SecKeychainFindGenericPassword(NULL, (UInt32)strlen(kRLMKeychainServiceName), kRLMKeychainServiceName, serverAddressLength, serverAddress, &plistLength, &plistPointer, NULL);
+    if (result != noErr || plistLength <= 0) return nil;
+    
+    NSData *plistData = [NSData dataWithBytes:plistPointer length:(NSUInteger)plistLength];
+    
+    NSDictionary *dict = [NSPropertyListSerialization propertyListWithData:plistData options:NSPropertyListImmutable format:NULL error:nil];
+    if (!dict) return nil;
+    
+    return [RLMKeychainInfo keychainInfoFromKeychainDictionary:dict];
+}
+
+#pragma mark Private
+
+- (NSDictionary *)keychainDictionaryFromCredentials:(RLMSyncCredentials *)credentials
+{
+    NSMutableDictionary *dict = [NSMutableDictionary new];
+    
+    dict[kRLMKeychainTokenKey] = credentials.token;
+    
+    if (credentials.userInfo) {
+        NSString *password = credentials.userInfo[kRLMKeychainPasswordKey];
+        if (password) dict[kRLMKeychainPasswordKey] = password;
+    }
+    
+    dict[kRLMKeychainProviderKey] = credentials.provider;
+    
+    return [dict copy];
+}
+
+@end
+
+@implementation RLMKeychainInfo (KeychainDictionary)
+
++ (instancetype)keychainInfoFromKeychainDictionary:(NSDictionary *)dict
+{
+    RLMKeychainInfo *info = [RLMKeychainInfo new];
+    
+    info.token = dict[kRLMKeychainTokenKey];
+    info.password = dict[kRLMKeychainPasswordKey];
+    info.provider = dict[kRLMKeychainProviderKey];
+    
+    return info;
+}
+
+@end

--- a/RealmBrowserSync/Resources/ConnectToServerWindow.xib
+++ b/RealmBrowserSync/Resources/ConnectToServerWindow.xib
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="RLMConnectToServerWindowController">
             <connections>
                 <outlet property="connectButton" destination="uRt-4w-Mjf" id="Cau-IC-MEI"/>
                 <outlet property="credentialsContainerView" destination="WTR-Iv-dY5" id="mCH-JO-F2d"/>
+                <outlet property="saveCredentialsCheckBox" destination="VRh-oT-1rA" id="VUI-gW-fWK"/>
                 <outlet property="serverURLTextField" destination="2i7-01-DBe" id="O9C-SE-ATR"/>
                 <outlet property="window" destination="QvC-M9-y7g" id="Bb2-l8-4UY"/>
             </connections>
@@ -18,10 +20,10 @@
         <window title="Connect to Object Server" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="500" height="247"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="800"/>
+            <rect key="contentRect" x="196" y="240" width="500" height="295"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
             <view key="contentView" id="EiT-Mj-1SZ">
-                <rect key="frame" x="0.0" y="0.0" width="500" height="247"/>
+                <rect key="frame" x="0.0" y="0.0" width="500" height="295"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uRt-4w-Mjf">
@@ -51,7 +53,7 @@ Gw
                         </connections>
                     </button>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2i7-01-DBe">
-                        <rect key="frame" x="20" y="180" width="460" height="22"/>
+                        <rect key="frame" x="20" y="228" width="460" height="22"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300" id="BfJ-SJ-6Xg"/>
                         </constraints>
@@ -76,7 +78,7 @@ Gw
                         </connections>
                     </textField>
                     <textField horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6SF-Re-3zi">
-                        <rect key="frame" x="18" y="210" width="77" height="17"/>
+                        <rect key="frame" x="18" y="258" width="77" height="17"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Server URL:" id="w6e-T2-wvV">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -84,32 +86,41 @@ Gw
                         </textFieldCell>
                     </textField>
                     <customView verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WTR-Iv-dY5">
-                        <rect key="frame" x="0.0" y="61" width="500" height="99"/>
+                        <rect key="frame" x="0.0" y="91" width="500" height="117"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="450" id="vgg-8V-Imx"/>
                         </constraints>
                     </customView>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VRh-oT-1rA">
+                        <rect key="frame" x="20" y="59" width="195" height="18"/>
+                        <buttonCell key="cell" type="check" title="Save credentials to keychain" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="JMw-Ky-Kml">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                    </button>
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="WTR-Iv-dY5" secondAttribute="trailing" id="0vs-av-bAt"/>
-                    <constraint firstAttribute="trailing" secondItem="uRt-4w-Mjf" secondAttribute="trailing" constant="20" id="1na-Ks-Ygl"/>
+                    <constraint firstAttribute="trailing" secondItem="uRt-4w-Mjf" secondAttribute="trailing" constant="20" symbolic="YES" id="1na-Ks-Ygl"/>
                     <constraint firstItem="2i7-01-DBe" firstAttribute="top" secondItem="6SF-Re-3zi" secondAttribute="bottom" constant="8" symbolic="YES" id="4CO-EI-gu4"/>
                     <constraint firstItem="2i7-01-DBe" firstAttribute="leading" secondItem="6SF-Re-3zi" secondAttribute="leading" id="4pz-qB-dSh"/>
                     <constraint firstItem="WTR-Iv-dY5" firstAttribute="top" secondItem="2i7-01-DBe" secondAttribute="bottom" constant="20" id="BpY-lD-vd4"/>
-                    <constraint firstAttribute="bottom" secondItem="HTQ-E5-jlI" secondAttribute="bottom" constant="20" id="EVL-d7-yn1"/>
-                    <constraint firstItem="HTQ-E5-jlI" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" id="Mfw-uP-JGL"/>
-                    <constraint firstItem="HTQ-E5-jlI" firstAttribute="top" secondItem="WTR-Iv-dY5" secondAttribute="bottom" constant="20" id="Ox7-6E-3iD"/>
+                    <constraint firstAttribute="bottom" secondItem="HTQ-E5-jlI" secondAttribute="bottom" constant="20" symbolic="YES" id="EVL-d7-yn1"/>
+                    <constraint firstItem="HTQ-E5-jlI" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" symbolic="YES" id="Mfw-uP-JGL"/>
+                    <constraint firstItem="HTQ-E5-jlI" firstAttribute="top" secondItem="VRh-oT-1rA" secondAttribute="bottom" constant="20" symbolic="YES" id="QZF-Kj-z59"/>
                     <constraint firstItem="2i7-01-DBe" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="20" symbolic="YES" id="Wl2-ic-T4S"/>
+                    <constraint firstItem="VRh-oT-1rA" firstAttribute="top" secondItem="WTR-Iv-dY5" secondAttribute="bottom" constant="16" id="XHh-Rm-YJP"/>
                     <constraint firstItem="WTR-Iv-dY5" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" id="Y1J-3f-pt1"/>
                     <constraint firstItem="6SF-Re-3zi" firstAttribute="top" secondItem="EiT-Mj-1SZ" secondAttribute="top" constant="20" symbolic="YES" id="kP2-zU-mee"/>
-                    <constraint firstAttribute="bottom" secondItem="uRt-4w-Mjf" secondAttribute="bottom" constant="20" id="yBx-lO-Pak"/>
+                    <constraint firstItem="VRh-oT-1rA" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" constant="22" id="tiX-4P-WB6"/>
+                    <constraint firstAttribute="bottom" secondItem="uRt-4w-Mjf" secondAttribute="bottom" constant="20" symbolic="YES" id="yBx-lO-Pak"/>
                     <constraint firstAttribute="trailing" secondItem="2i7-01-DBe" secondAttribute="trailing" constant="20" symbolic="YES" id="yMj-9p-GGe"/>
                 </constraints>
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="buF-7D-bNq"/>
             </connections>
-            <point key="canvasLocation" x="289" y="290.5"/>
+            <point key="canvasLocation" x="288" y="309.5"/>
         </window>
     </objects>
 </document>


### PR DESCRIPTION
This implements #268 

Username and password (or token) are saved to the keychain if the option is selected in the UI. I left the default as on since I think most people will want this, but maybe you want to change it to be opt-in.

The credentials are associated with a specific server URL, when editing the URL, if a match is found, the corresponding username and password fields (or the token field) are automatically filled in.

![keychain](https://cloud.githubusercontent.com/assets/67184/24940666/f1126a6a-1f1a-11e7-8f68-f1bbccf19ed3.gif)
