### PR TITLE
Temporary workaround for #297

### DIFF
--- a/RealmBrowser/Models/RLMDocument.m
+++ b/RealmBrowser/Models/RLMDocument.m
@@ -173,14 +173,16 @@
             } else {
                 self.user = user;
 
-                // FIXME: workaround for loading schema while using dynamic API
-                self.schemaLoader = [[RLMDynamicSchemaLoader alloc] initWithSyncURL:self.syncURL user:self.user];
+                NSString *path = [[NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) firstObject] stringByAppendingPathComponent:[[NSBundle mainBundle] bundleIdentifier]];
+                NSURL *localURL = [NSURL fileURLWithPath:[path stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]]];
+
+                self.schemaLoader = [[RLMDynamicSchemaLoader alloc] initWithSyncURL:self.syncURL localURL:localURL user:self.user];
 
                 [self.schemaLoader loadSchemaWithCompletionHandler:^(NSError *error) {
                     self.schemaLoader = nil;
 
                     if (error == nil) {
-                        self.presentedRealm = [[RLMRealmNode alloc] initWithSyncURL:self.syncURL user:self.user];
+                        self.presentedRealm = [[RLMRealmNode alloc] initWithSyncURL:self.syncURL localURL:localURL user:self.user];
 
                         [self loadWithError:&error];
                     } else {

--- a/RealmBrowser/Models/RLMRealmNode.h
+++ b/RealmBrowser/Models/RLMRealmNode.h
@@ -31,7 +31,7 @@
 @property (nonatomic, assign) BOOL disableFormatUpgrade;
 
 - (instancetype)initWithFileURL:(NSURL *)fileURL;
-- (instancetype)initWithSyncURL:(NSURL *)syncURL user:(RLMSyncUser *)user;
+- (instancetype)initWithSyncURL:(NSURL *)syncURL localURL:(NSURL *)localURL user:(RLMSyncUser *)user;
 
 - (BOOL)connect:(NSError **)error;
 

--- a/RealmBrowser/Models/RLMRealmNode.m
+++ b/RealmBrowser/Models/RLMRealmNode.m
@@ -43,13 +43,17 @@
     return self;
 }
 
-- (instancetype)initWithSyncURL:(NSURL *)syncURL user:(RLMSyncUser *)user {
+- (instancetype)initWithSyncURL:(NSURL *)syncURL localURL:(NSURL *)localURL user:(RLMSyncUser *)user {
     self = [super init];
 
     if (self) {
         self.configuration = [[RLMRealmConfiguration alloc] init];
         self.configuration.dynamic = YES;
-        self.configuration.syncConfiguration = [[RLMSyncConfiguration alloc] initWithUser:user realmURL:syncURL];
+
+        RLMSyncConfiguration *syncConfiguration = [[RLMSyncConfiguration alloc] initWithUser:user realmURL:syncURL];
+        syncConfiguration.customFileURL = localURL;
+
+        self.configuration.syncConfiguration = syncConfiguration;
     }
 
     return self;

--- a/RealmBrowserSync/Controllers/RLMSyncServerBrowserWindowController.m
+++ b/RealmBrowserSync/Controllers/RLMSyncServerBrowserWindowController.m
@@ -79,7 +79,7 @@ static NSString * const RLMAdminRealmRealmFileClassName = @"RealmFile";
 
     NSURL *adminRealmURL = [self.serverURL URLByAppendingPathComponent:RLMAdminRealmServerPath];
 
-    self.schemaLoader = [[RLMDynamicSchemaLoader alloc] initWithSyncURL:adminRealmURL user:self.user];
+    self.schemaLoader = [[RLMDynamicSchemaLoader alloc] initWithSyncURL:adminRealmURL localURL:nil user:self.user];
 
     __weak typeof(self) weakSelf = self;
     [self.schemaLoader loadSchemaWithCompletionHandler:^(NSError *error) {

--- a/RealmBrowserSync/Library/RLMDynamicSchemaLoader.h
+++ b/RealmBrowserSync/Library/RLMDynamicSchemaLoader.h
@@ -22,7 +22,7 @@ typedef void (^RLMSchemaLoadCompletionHandler)(NSError *error);
 
 @interface RLMDynamicSchemaLoader : NSObject
 
-- (instancetype)initWithSyncURL:(NSURL *)syncURL user:(RLMSyncUser *)user;
+- (instancetype)initWithSyncURL:(NSURL *)syncURL localURL:(NSURL *)localURL user:(RLMSyncUser *)user;
 
 - (void)loadSchemaWithCompletionHandler:(RLMSchemaLoadCompletionHandler)handler;
 - (void)cancelSchemaLoading;

--- a/RealmBrowserSync/Library/RLMDynamicSchemaLoader.m
+++ b/RealmBrowserSync/Library/RLMDynamicSchemaLoader.m
@@ -34,7 +34,7 @@ NSString * const errorDomain = @"RLMDynamicSchemaLoader";
 
 @implementation RLMDynamicSchemaLoader
 
-- (instancetype)initWithSyncURL:(NSURL *)syncURL user:(RLMSyncUser *)user {
+- (instancetype)initWithSyncURL:(NSURL *)syncURL localURL:(NSURL *)localURL user:(RLMSyncUser *)user {
     NSAssert(user.state == RLMSyncUserStateActive, @"User must be logged in");
 
     self = [super init];
@@ -42,7 +42,11 @@ NSString * const errorDomain = @"RLMDynamicSchemaLoader";
     if (self != nil) {
         self.configuration = [[RLMRealmConfiguration alloc] init];
         self.configuration.dynamic = YES;
-        self.configuration.syncConfiguration = [[RLMSyncConfiguration alloc] initWithUser:user realmURL:syncURL];
+
+        RLMSyncConfiguration *syncConfiguration = [[RLMSyncConfiguration alloc] initWithUser:user realmURL:syncURL];
+        syncConfiguration.customFileURL = localURL;
+
+        self.configuration.syncConfiguration = syncConfiguration;
     }
 
     return self;


### PR DESCRIPTION
refs #297 

For some reason ObjectStore fails to read a schema with dynamic API if the there is a local copy of synced realm. This issue needs more time for investigation. Because of the urgency as a temporary workaround we can specify a unique `customFileURL` for `syncConfiguration` which forces sync to create a new local copy for every realm URL. Seems to work so far.

/cc @dhmspector, @jpsim 