### PR TITLE
Programmatically construct search predicates in a saner way

### DIFF
--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -558,6 +558,10 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
 
     NSMutableArray *predicates = [NSMutableArray array];
 
+    NSNumberFormatter *floatFormatter = [[NSNumberFormatter alloc] init];
+    NSNumberFormatter *integerFormatter = [[NSNumberFormatter alloc] init];
+    integerFormatter.allowsFloats = NO;
+
     for (NSUInteger index = 0; index < columnCount; index++) {
 
         RLMClassProperty *property = columns[index];
@@ -579,17 +583,10 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
                 break;
             }
             case RLMPropertyTypeInt: {
-                long long value;
-                if ([searchText isEqualToString:@"0"]) {
-                    value = 0;
+                NSNumber *value = [integerFormatter numberFromString:searchText];
+                if (value) {
+                    valueExpression = [NSExpression expressionForConstantValue:value];
                 }
-                else {
-                    value = [searchText longLongValue];
-                    if (value == 0)
-                        break;
-                }
-
-                valueExpression = [NSExpression expressionForConstantValue:@(value)];
                 break;
             }
             case RLMPropertyTypeString: {
@@ -601,19 +598,10 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
             }
             //case RLMPropertyTypeFloat: // search on float columns disabled until bug is fixed in binding
             case RLMPropertyTypeDouble: {
-                double value;
-
-                if ([searchText isEqualToString:@"0"] ||
-                    [searchText isEqualToString:@"0.0"]) {
-                    value = 0.0;
+                NSNumber *value = [floatFormatter numberFromString:searchText];
+                if (value) {
+                    valueExpression = [NSExpression expressionForConstantValue:value];
                 }
-                else {
-                    value = [searchText doubleValue];
-                    if (value == 0.0)
-                        break;
-                }
-
-                valueExpression = [NSExpression expressionForConstantValue:@(value)];
                 break;
             }
             default:

--- a/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
+++ b/RealmBrowser/Controllers/RLMRealmBrowserWindowController.m
@@ -596,7 +596,7 @@ static void const *kWaitForDocumentSchemaLoadObservationContext;
 
                 break;
             }
-            //case RLMPropertyTypeFloat: // search on float columns disabled until bug is fixed in binding
+            case RLMPropertyTypeFloat:
             case RLMPropertyTypeDouble: {
                 NSNumber *value = [floatFormatter numberFromString:searchText];
                 if (value) {


### PR DESCRIPTION
Convert search terms into `NSExpression`s and assemble them into `NSComparisonPredicate`s, which are then combined into a `NSCompoundPredicate`. This is preferable to building up format strings because it completely sidesteps the need to worry about escaping any special characters.

I also switched to using `NSNumberFormatter` to parse integers and floating point values from strings. This avoids having a search term of "1.2" match any integer column with a value of 1, which seemed like confusing behavior. It also results in more consistent handling of whitespace around numbers, which previously differed between zero and non-zero values (" 0" would be ignored, while " 1" would be respected).

I've only lightly tested this.

Fixes #313.