### PR TITLE
Add Objective-C nullability annotations to model definitions

### DIFF
--- a/RealmBrowser/Support/RLMModelExporter.m
+++ b/RealmBrowser/Support/RLMModelExporter.m
@@ -273,13 +273,18 @@
     }
     [hContents appendString:@"\n\n"];
     
+    [hContents appendString:@"NS_ASSUME_NONNULL_BEGIN\n\n"];
+    
     for (RLMObjectSchema *schema in schemas) {
         [hContents appendFormat:@"@interface %@()\n\n", schema.className];
         for (RLMProperty *property in schema.properties) {
-            [hContents appendFormat:@"@property %@%@;\n", [self objcNameForProperty:property], property.name];
+            [hContents appendFormat:@"@property %@%@%@;\n", property.optional ? @"(nullable) " : @"", [self objcNameForProperty:property], property.name];
         }
-        [hContents appendString:@"\n@end\n\n\n"];
+        [hContents appendString:@"\n@end\n\n"];
     }
+    
+    [hContents appendString:@"NS_ASSUME_NONNULL_END\n"];
+    
     // An array with filename and contents for the h-file model
     NSArray *hModel = @[hFilename, hContents];
     


### PR DESCRIPTION
Hi there,

These annotations help a lot when interacting with Realm Objective-C models from Swift.  We were previously adding them to our generated models by hand.

To test I replaced the manually edited files in our project (20 models) with ones automatically generated with this commit.  No errors and additionally found a few places where we had forgotten the manual `(nullable)` attributes.  

Cheers