### PR TITLE
Log out sync users on startup and shutdown

### DIFF
--- a/RealmBrowser/Models/RLMDocument.m
+++ b/RealmBrowser/Models/RLMDocument.m
@@ -110,8 +110,6 @@
 }
 
 - (void)dealloc {
-    [self.user logOut];
-
     if (self.securityScopedURL != nil) {
         //In certain instances, RLMRealm's C++ destructor method will attempt to clean up
         //specific auxiliary files belonging to this realm file.


### PR DESCRIPTION
In case if the same credentials are used to open multiple realm urls (the most common scenario I guess) closing the Browser's window forces user to log out which means that all the connections associated with this user are terminated. To prevent that and to clean up the cached realm on disk I makes sense to log out all the valid sync users on app termination + app launch (if the app wasn't terminated properly).