### PR TITLE
Add object links to arrays

### DIFF
--- a/RealmBrowser/Controllers/RLMInstanceTableViewController.m
+++ b/RealmBrowser/Controllers/RLMInstanceTableViewController.m
@@ -573,9 +573,13 @@ typedef NS_ENUM(int32_t, RLMUpdateType) {
     popoverContent.didSelectedBlock = ^(RLMObject *object) {
         RLMRealm *realm = weakSelf.parentWindowController.document.presentedRealm.realm;
         [realm beginWriteTransaction];
-        
-        selectedInstance[property.name] = object;
-        
+
+        if ([self propertyTypeForColumn: columnIndex] == RLMPropertyTypeArray) {
+            [(RLMArray*)selectedInstance[property.name] addObject:object];
+        } else {
+            selectedInstance[property.name] = object;
+        }
+
         [realm commitWriteTransaction];
         [weakPopover close];
     };

--- a/RealmBrowser/Models/RLMArrayNode.h
+++ b/RealmBrowser/Models/RLMArrayNode.h
@@ -26,5 +26,6 @@
 - (BOOL)removeInstanceAtIndex:(NSUInteger)index;
 - (BOOL)moveInstanceFromIndex:(NSUInteger)fromIndex toIndex:(NSUInteger)toIndex;
 //- (BOOL)isEqualTo:(id)object;
+- (NSString *)objectClassName;
 
 @end

--- a/RealmBrowser/Models/RLMArrayNode.m
+++ b/RealmBrowser/Models/RLMArrayNode.m
@@ -107,6 +107,11 @@
     return YES;
 }
 
+- (NSString *)objectClassName
+{
+    return [displayedArray.objectClassName copy];
+}
+
 #pragma mark - RLMTypeNode Overrides
 
 - (NSString *)name

--- a/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
+++ b/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -250,10 +250,16 @@ CA
                                     <action selector="deleteRowsFromArrayAction:" target="-1" id="cOY-tf-Nwc"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Add New Objects to Array" tag="112" keyEquivalent="+" id="NDc-iI-dKd">
+                            <menuItem title="Add New Object to Array" tag="112" keyEquivalent="+" id="NDc-iI-dKd">
                                 <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="addRowsToArrayAction:" target="-1" id="v6Y-zi-8rX"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Add Existing Object to Array" tag="113" keyEquivalent="+" id="OUC-JK-qjs">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="insertRowsToArrayAction:" target="-1" id="Yxs-Xk-68j"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/RealmBrowser/Views/RLMTableView.h
+++ b/RealmBrowser/Views/RLMTableView.h
@@ -69,6 +69,8 @@ typedef struct {
 
 - (void)addNewRows:(NSIndexSet *)rowIndexes;
 
+- (void)insertLinks:(NSIndexSet *)rowIndexes column:(NSInteger)columnIndex;
+
 // Operations on links in cells
 - (void)setObjectLinkAtRows:(NSIndexSet *)rowIndexes column:(NSInteger)columnIndex;
 

--- a/RealmBrowser/Views/RLMTableView.m
+++ b/RealmBrowser/Views/RLMTableView.m
@@ -41,7 +41,8 @@ const NSInteger NOT_A_COLUMN = -1;
     NSMenuItem *removeFromArrayItem;
     NSMenuItem *deleteRowItem;
     NSMenuItem *insertIntoArrayItem;
-    
+    NSMenuItem *insertLinkInArray;
+
     NSMenuItem *setLinkToObjectItem;
     NSMenuItem *removeLinkToObjectItem;
     NSMenuItem *removeLinkToArrayItem;
@@ -124,7 +125,12 @@ const NSInteger NOT_A_COLUMN = -1;
                                                      action:@selector(addRowsToArrayAction:)
                                               keyEquivalent:@""];
     insertIntoArrayItem.tag = 212;
-    
+
+    insertLinkInArray = [[NSMenuItem alloc] initWithTitle:@"Add existing object to array"
+                                                     action:@selector(insertRowsToArrayAction:)
+                                              keyEquivalent:@""];
+    insertLinkInArray.tag = 213;
+
     // Operations on links in cells
     setLinkToObjectItem = [[NSMenuItem alloc] initWithTitle:@"Add link to object"
                                                      action:@selector(setObjectLinkAction:)
@@ -160,7 +166,7 @@ const NSInteger NOT_A_COLUMN = -1;
     // Menu items that are independent on the realm lock
     if (actualColumn && [self.realmDelegate containsArrayInRows:self.selectedRowIndexes column:self.clickedColumn]) {
         [self.menu addItem:openArrayInNewWindowItem];
-        [self.menu addItem:setLinkToObjectItem];
+        [self.menu addItem:insertLinkInArray];
     }
     
     // If it is locked, show the unlock hint menu item and return
@@ -173,6 +179,7 @@ const NSInteger NOT_A_COLUMN = -1;
     
     if (self.realmDelegate.displaysArray) {
         [self.menu addItem:insertIntoArrayItem];
+        [self.menu addItem:insertLinkInArray];
     }
     
     if (actualColumn && [self.realmDelegate isColumnObjectType:self.clickedColumn]) {
@@ -377,6 +384,16 @@ const NSInteger NOT_A_COLUMN = -1;
         NSInteger index = self.selectedRowIndexes.count > 0 ? self.selectedRowIndexes.lastIndex + 1 : self.numberOfRows;
 
         [self.realmDelegate addNewRows:[NSIndexSet indexSetWithIndex:index]];
+    }
+}
+
+// Insert link into array
+- (IBAction)insertRowsToArrayAction:(id)sender
+{
+    if (self.realmDelegate.displaysArray && !self.realmDelegate.realmIsLocked) {
+        NSInteger index = self.selectedRowIndexes.count > 0 ? self.selectedRowIndexes.lastIndex + 1 : self.numberOfRows;
+
+        [self.realmDelegate insertLinks:[NSIndexSet indexSetWithIndex:index] column:self.clickedColumn];
     }
 }
 

--- a/RealmBrowser/Views/RLMTableView.m
+++ b/RealmBrowser/Views/RLMTableView.m
@@ -319,6 +319,11 @@ const NSInteger NOT_A_COLUMN = -1;
         case 212: // Context -> Insert object into array
             menuItem.title = [NSString stringWithFormat:@"Add new object%@ to array", numberModifier];
             return unlocked && displaysArray;
+
+        case 113: // Edit -> Add existing object to array
+        case 213: // Context -> Add existing object to array
+            menuItem.title = [NSString stringWithFormat:@"Add existing object%@ to array", numberModifier];
+            return unlocked && displaysArray;
             
         case 220: // Context -> Remove links to object
             menuItem.title = [NSString stringWithFormat:@"Remove link%@ to object%@", numberModifier, numberModifier];

--- a/RealmBrowser/Views/RLMTableView.m
+++ b/RealmBrowser/Views/RLMTableView.m
@@ -160,6 +160,7 @@ const NSInteger NOT_A_COLUMN = -1;
     // Menu items that are independent on the realm lock
     if (actualColumn && [self.realmDelegate containsArrayInRows:self.selectedRowIndexes column:self.clickedColumn]) {
         [self.menu addItem:openArrayInNewWindowItem];
+        [self.menu addItem:setLinkToObjectItem];
     }
     
     // If it is locked, show the unlock hint menu item and return


### PR DESCRIPTION
As discussed with @stel 

This PR addresses: https://github.com/realm/realm-browser-osx/issues/287 and the last remaining portion of https://github.com/realm/realm-browser-osx/issues/45

1) Adds a popup menu item when right clicking on an array cell allowing for adding links into the cell.
2) Adds a popup menu item to either insert or append links when viewing an array's contents in a new window.

The functionality to open a list of objects was already in and was used to set 1-to-1 links. This PR reuses this code and mostly deals with adding the neccessary UI.