### PR TITLE
Add upgrade info for Realm Studio

### DIFF
--- a/RealmBrowser/Application/RLMApplicationDelegate.m
+++ b/RealmBrowser/Application/RLMApplicationDelegate.m
@@ -170,6 +170,8 @@
 #pragma mark - Welcome Window
 
 - (IBAction)showWelcomeWindow:(id)sender {
+    static BOOL toutDisplayedDuringAppRun = NO;
+    static NSString *toutSuppressionKey = @"RealmStudio_suppress_tout";
     RLMWelcomeWindowController *welcomeWindowController = [[RLMWelcomeWindowController alloc] init];
 
     [welcomeWindowController.window center];
@@ -178,6 +180,23 @@
     }];
 
     [self addAuxiliaryWindowController:welcomeWindowController];
+    if (!toutDisplayedDuringAppRun && ![[NSUserDefaults standardUserDefaults] boolForKey:toutSuppressionKey]) {
+        toutDisplayedDuringAppRun = YES;
+        NSAlert *upgradeAlert = [[NSAlert alloc] init];
+        [upgradeAlert addButtonWithTitle:@"OK"];
+        [upgradeAlert addButtonWithTitle:@"Learn more..."];
+        [upgradeAlert setShowsSuppressionButton:YES];
+        [upgradeAlert setMessageText:@"Realm Browser is deprecated"];
+        [upgradeAlert setInformativeText:@"Realm Browser has been replaced by Realm Studio. Realm Studio is required to open synchronized Realms for a Realm Object Server version 2.0 or later."];
+        NSInteger result = [upgradeAlert runModal];
+        if (result == NSAlertSecondButtonReturn) {
+            // Open the web site.
+            [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://realm.io/products/realm-studio/"]];
+        }
+        if ([upgradeAlert suppressionButton].state == NSControlStateValueOn) {
+            [[NSUserDefaults standardUserDefaults] setBool:YES forKey:toutSuppressionKey];
+        }
+    }
 }
 
 #pragma mark - Event handling
@@ -736,6 +755,12 @@
     [[RLMSyncUser allUsers] enumerateKeysAndObjectsUsingBlock:^(NSString *key, RLMSyncUser *user, BOOL *stop) {
         [user logOut];
     }];
+}
+
+#pragma mark - Other
+
+- (IBAction)visitRealmStudioSite:(NSMenuItem *)sender {
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://realm.io/products/realm-studio/"]];
 }
 
 @end

--- a/RealmBrowser/Application/RLMApplicationDelegate.m
+++ b/RealmBrowser/Application/RLMApplicationDelegate.m
@@ -183,17 +183,17 @@
     if (!toutDisplayedDuringAppRun && ![[NSUserDefaults standardUserDefaults] boolForKey:toutSuppressionKey]) {
         toutDisplayedDuringAppRun = YES;
         NSAlert *upgradeAlert = [[NSAlert alloc] init];
-        [upgradeAlert addButtonWithTitle:@"OK"];
-        [upgradeAlert addButtonWithTitle:@"Learn more..."];
+        [upgradeAlert addButtonWithTitle:@"Get Realm Studio..."];
+        [upgradeAlert addButtonWithTitle:@"Not now"];
         [upgradeAlert setShowsSuppressionButton:YES];
         [upgradeAlert setMessageText:@"Realm Browser is deprecated"];
-        [upgradeAlert setInformativeText:@"Realm Browser has been replaced by Realm Studio. Realm Studio is required to open synchronized Realms for a Realm Object Server version 2.0 or later."];
+        [upgradeAlert setInformativeText:@"Realm Browser has been replaced by Realm Studio. Bug fixes and enhancements will only be available via Realm Studio going forwards."];
         NSInteger result = [upgradeAlert runModal];
-        if (result == NSAlertSecondButtonReturn) {
+        if (result == NSAlertFirstButtonReturn) {
             // Open the web site.
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://realm.io/products/realm-studio/"]];
         }
-        if ([upgradeAlert suppressionButton].state == NSControlStateValueOn) {
+        if ([upgradeAlert suppressionButton].state == NSOnState) {
             [[NSUserDefaults standardUserDefaults] setBool:YES forKey:toutSuppressionKey];
         }
     }

--- a/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
+++ b/RealmBrowser/Resources/UI/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -336,6 +336,12 @@ CA
                             <menuItem title="Realm Browser Help" keyEquivalent="?" id="FKE-Sm-Kum">
                                 <connections>
                                     <action selector="showHelp:" target="-1" id="y7X-2Q-9no"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Visit Realm Studio Website" id="pv3-Ik-bUn">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="visitRealmStudioSite:" target="PLw-ns-0qo" id="BoC-G4-nUt"/>
                                 </connections>
                             </menuItem>
                         </items>


### PR DESCRIPTION
Changes:
- Add an alert dialog that accompanies the welcome screen informing user about Realm Studio
- Add a menu item in the Help menu that takes users to the Realm Studio website

(_screenshot updated_)

<img width="532" alt="new1" src="https://user-images.githubusercontent.com/3687054/33861292-f0d952b6-de91-11e7-9035-c0e833b57dc8.png">

(The "Learn More..." button dismisses the dialog and opens the Realm Studio web site in the user's default browser.)

Fixes #364